### PR TITLE
feat: update model mapping and improve model selection guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ Ask Gemini to redesign the database connection to be more resilient.
 
 **Notes:**
 
-- if you do not pass `--model`, Gemini chooses its own defaults
-- model aliases: `pro` (gemini-2.5-pro), `flash` (gemini-2.5-flash), `flash-lite` (gemini-2.5-flash-lite)
-- you can also pass concrete model names like `gemini-3-pro-preview`
+- if you do not pass `--model`, the plugin defaults to `auto-gemini-3` (routes to the best available Gemini 3.x model)
+- auto-routing aliases: `auto-gemini-3` (default), `auto-gemini-2.5`, `pro`, `flash` (→ `gemini-3-flash-preview`), `flash-lite` (→ `gemini-3.1-flash-lite-preview`)
+- concrete model IDs: `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`
 - follow-up rescue requests can continue the latest Gemini task in the repo
 
 ### `/gemini:status`

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Ask Gemini to redesign the database connection to be more resilient.
 **Notes:**
 
 - if you do not pass `--model`, the plugin defaults to `auto-gemini-3` (routes to the best available Gemini 3.x model)
-- auto-routing aliases: `auto-gemini-3` (default), `auto-gemini-2.5`, `pro`, `flash` (→ `gemini-3-flash-preview`), `flash-lite` (→ `gemini-3.1-flash-lite-preview`)
+- model aliases: `pro` (→ `gemini-3.1-pro-preview`), `flash` (→ `gemini-3-flash-preview`), `flash-lite` (→ `gemini-3.1-flash-lite-preview`), `auto-gemini-3` (default), `auto-gemini-2.5`
 - concrete model IDs: `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`
 - follow-up rescue requests can continue the latest Gemini task in the repo
 

--- a/plugins/gemini/agents/gemini-rescue.md
+++ b/plugins/gemini/agents/gemini-rescue.md
@@ -27,10 +27,13 @@ Forwarding rules:
 - Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own.
 - Do not call `review`, `adversarial-review`, `status`, `result`, or `cancel`. This subagent only forwards to `task`.
 - Leave `--thinking-budget` unset unless the user explicitly requests a specific thinking budget.
-- Leave model unset by default. Only add `--model` when the user explicitly asks for a specific model.
-- If the user asks for `flash`, map that to `--model gemini-2.5-flash`.
-- If the user asks for `flash-lite`, map that to `--model gemini-2.5-flash-lite`.
-- If the user asks for a concrete model name such as `gemini-3-pro-preview`, pass it through with `--model`.
+- The default model is `auto-gemini-3`. Leave `--model` unset unless the user explicitly asks for a different model — the runtime applies the default automatically.
+- If the user specifies a model, pass it as `--model <name>`. Accepted values:
+  - Auto-routing: `auto-gemini-3`, `auto-gemini-2.5`, `pro`, `flash`, `flash-lite`
+  - Gemini 3.x concrete: `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
+  - Gemini 2.5 concrete: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`
+- If the user asks for `flash`, map that to `--model gemini-3-flash-preview`.
+- If the user asks for `flash-lite`, map that to `--model gemini-3.1-flash-lite-preview`.
 - Treat `--thinking-budget <value>` and `--model <value>` as runtime controls and do not include them in the task text you pass through.
 - Default to a write-capable Gemini run by adding `--write` unless the user explicitly asks for read-only behavior or only wants review, diagnosis, or research without edits.
 - Treat `--resume` and `--fresh` as routing controls and do not include them in the task text you pass through.

--- a/plugins/gemini/agents/gemini-rescue.md
+++ b/plugins/gemini/agents/gemini-rescue.md
@@ -29,9 +29,10 @@ Forwarding rules:
 - Leave `--thinking-budget` unset unless the user explicitly requests a specific thinking budget.
 - The default model is `auto-gemini-3`. Leave `--model` unset unless the user explicitly asks for a different model — the runtime applies the default automatically.
 - If the user specifies a model, pass it as `--model <name>`. Accepted values:
-  - Auto-routing: `auto-gemini-3`, `auto-gemini-2.5`, `pro`, `flash`, `flash-lite`
+  - Shorthand aliases: `pro` (→ `gemini-3.1-pro-preview`), `flash` (→ `gemini-3-flash-preview`), `flash-lite` (→ `gemini-3.1-flash-lite-preview`), `auto-gemini-3`, `auto-gemini-2.5`
   - Gemini 3.x concrete: `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
   - Gemini 2.5 concrete: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`
+- If the user asks for `pro`, map that to `--model gemini-3.1-pro-preview`.
 - If the user asks for `flash`, map that to `--model gemini-3-flash-preview`.
 - If the user asks for `flash-lite`, map that to `--model gemini-3.1-flash-lite-preview`.
 - Treat `--thinking-budget <value>` and `--model <value>` as runtime controls and do not include them in the task text you pass through.

--- a/plugins/gemini/agents/gemini-rescue.md
+++ b/plugins/gemini/agents/gemini-rescue.md
@@ -28,7 +28,7 @@ Forwarding rules:
 - Do not call `review`, `adversarial-review`, `status`, `result`, or `cancel`. This subagent only forwards to `task`.
 - Leave `--thinking-budget` unset unless the user explicitly requests a specific thinking budget.
 - The default model is `auto-gemini-3`. Leave `--model` unset unless the user explicitly asks for a different model — the runtime applies the default automatically.
-- If the user specifies a model, pass it as `--model <name>`. Accepted values:
+- If the user specifies a model, pass it as `--model <name>`. The runtime forwards the value to Gemini CLI; any model ID supported by Gemini CLI is valid. Common values include:
   - Shorthand aliases: `pro` (→ `gemini-3.1-pro-preview`), `flash` (→ `gemini-3-flash-preview`), `flash-lite` (→ `gemini-3.1-flash-lite-preview`), `auto-gemini-3`, `auto-gemini-2.5`
   - Gemini 3.x concrete: `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
   - Gemini 2.5 concrete: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`

--- a/plugins/gemini/commands/adversarial-review.md
+++ b/plugins/gemini/commands/adversarial-review.md
@@ -1,6 +1,6 @@
 ---
 description: Run a steerable adversarial Gemini review of working-tree or branch changes in this repository
-argument-hint: '[focus text] [--base <ref>] [--scope <auto|working-tree|branch>] [--wait|--background] [--model <name>] [--json]'
+argument-hint: '[focus text] [--base <ref>] [--scope <auto|working-tree|branch>] [--wait|--background] [--model auto-gemini-3|flash|flash-lite|<model-id>] [--json]'
 disable-model-invocation: true
 allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(git:*), AskUserQuestion
 ---

--- a/plugins/gemini/commands/adversarial-review.md
+++ b/plugins/gemini/commands/adversarial-review.md
@@ -1,6 +1,6 @@
 ---
 description: Run a steerable adversarial Gemini review of working-tree or branch changes in this repository
-argument-hint: '[focus text] [--base <ref>] [--scope <auto|working-tree|branch>] [--wait|--background] [--model auto-gemini-3|flash|flash-lite|<model-id>] [--json]'
+argument-hint: '[focus text] [--base <ref>] [--scope <auto|working-tree|branch>] [--wait|--background] [--model auto-gemini-3|auto-gemini-2.5|pro|flash|flash-lite|<model-id>] [--json]'
 disable-model-invocation: true
 allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(git:*), AskUserQuestion
 ---

--- a/plugins/gemini/commands/rescue.md
+++ b/plugins/gemini/commands/rescue.md
@@ -42,10 +42,10 @@ Invocation:
 - Leave `--thinking-budget` unset unless the user explicitly asks for a specific thinking budget.
 - The default model is `auto-gemini-3`. Leave `--model` unset unless the user explicitly names a different model — the runtime applies the default automatically.
 - If the user specifies a model name, pass it as `--model <name>`. Accepted values:
-  - Auto-routing: `auto-gemini-3`, `auto-gemini-2.5`, `pro`, `flash`, `flash-lite`
+  - Shorthand aliases: `pro` (→ `gemini-3.1-pro-preview`), `flash` (→ `gemini-3-flash-preview`), `flash-lite` (→ `gemini-3.1-flash-lite-preview`), `auto-gemini-3`, `auto-gemini-2.5`
   - Gemini 3.x concrete: `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
   - Gemini 2.5 concrete: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`
-- `flash` resolves to `gemini-3-flash-preview`; `flash-lite` resolves to `gemini-3.1-flash-lite-preview`. Use them only when the user explicitly requests speed over capability.
+- `pro` resolves to `gemini-3.1-pro-preview` (use for deep reasoning, complex implementation, security analysis). `flash` resolves to `gemini-3-flash-preview` and `flash-lite` resolves to `gemini-3.1-flash-lite-preview` — use those only when the user explicitly requests speed over capability.
 - Treat `--resume` as `--resume-last` when building the command.
 - Treat `--fresh` as meaning do not add `--resume-last`.
 - Strip `--resume`, `--fresh`, `--background`, and `--wait` from the task text.

--- a/plugins/gemini/commands/rescue.md
+++ b/plugins/gemini/commands/rescue.md
@@ -45,7 +45,7 @@ Invocation:
   - Shorthand aliases: `pro` (→ `gemini-3.1-pro-preview`), `flash` (→ `gemini-3-flash-preview`), `flash-lite` (→ `gemini-3.1-flash-lite-preview`), `auto-gemini-3`, `auto-gemini-2.5`
   - Gemini 3.x concrete: `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
   - Gemini 2.5 concrete: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`
-- `pro` resolves to `gemini-3.1-pro-preview` (use for deep reasoning, complex implementation, security analysis). `flash` resolves to `gemini-3-flash-preview` and `flash-lite` resolves to `gemini-3.1-flash-lite-preview` — use those only when the user explicitly requests speed over capability.
+- `pro` resolves to `gemini-3.1-pro-preview` (use for deep reasoning, complex implementation, security analysis). `flash` resolves to `gemini-3-flash-preview`; `flash-lite` resolves to `gemini-3.1-flash-lite-preview`. These aliases are optimized for speed-sensitive scenarios and are honored whenever the user explicitly passes them.
 - Treat `--resume` as `--resume-last` when building the command.
 - Treat `--fresh` as meaning do not add `--resume-last`.
 - Strip `--resume`, `--fresh`, `--background`, and `--wait` from the task text.

--- a/plugins/gemini/commands/rescue.md
+++ b/plugins/gemini/commands/rescue.md
@@ -1,6 +1,6 @@
 ---
 description: Delegate a task to Gemini for debugging, implementation, or deeper investigation
-argument-hint: "[--background|--wait] [--resume|--fresh] [--model <name>] [--thinking-budget <number>] [--approval-mode <mode>] [what Gemini should investigate, solve, or continue]"
+argument-hint: "[--background|--wait] [--resume|--fresh] [--model auto-gemini-3|auto-gemini-2.5|pro|flash|flash-lite|<concrete-model-id>] [--thinking-budget <number>] [--approval-mode <mode>] [what Gemini should investigate, solve, or continue]"
 context: fork
 allowed-tools: Bash(node:*), AskUserQuestion
 ---
@@ -40,8 +40,12 @@ Invocation:
 - Use exactly one `Bash` call to invoke `node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" task ...` and return that command's stdout as-is.
 - Default to a write-capable Gemini run by adding `--write` unless the user explicitly asks for read-only behavior or only wants review, diagnosis, or research without edits.
 - Leave `--thinking-budget` unset unless the user explicitly asks for a specific thinking budget.
-- Leave the model unset unless the user explicitly asks for one. If they ask for `flash`, map it to `--model gemini-2.5-flash`. If they ask for `flash-lite`, map it to `--model gemini-2.5-flash-lite`.
-- If the user asks for a concrete model name such as `gemini-3-pro-preview`, pass it through with `--model`.
+- The default model is `auto-gemini-3`. Leave `--model` unset unless the user explicitly names a different model — the runtime applies the default automatically.
+- If the user specifies a model name, pass it as `--model <name>`. Accepted values:
+  - Auto-routing: `auto-gemini-3`, `auto-gemini-2.5`, `pro`, `flash`, `flash-lite`
+  - Gemini 3.x concrete: `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
+  - Gemini 2.5 concrete: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`
+- `flash` resolves to `gemini-3-flash-preview`; `flash-lite` resolves to `gemini-3.1-flash-lite-preview`. Use them only when the user explicitly requests speed over capability.
 - Treat `--resume` as `--resume-last` when building the command.
 - Treat `--fresh` as meaning do not add `--resume-last`.
 - Strip `--resume`, `--fresh`, `--background`, and `--wait` from the task text.

--- a/plugins/gemini/commands/review.md
+++ b/plugins/gemini/commands/review.md
@@ -1,6 +1,6 @@
 ---
 description: Run a Gemini code review of working-tree or branch changes in this repository
-argument-hint: '[--base <ref>] [--scope <auto|working-tree|branch>] [--wait|--background] [--model <name>] [--json]'
+argument-hint: '[--base <ref>] [--scope <auto|working-tree|branch>] [--wait|--background] [--model auto-gemini-3|flash|flash-lite|<model-id>] [--json]'
 disable-model-invocation: true
 allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(git:*), AskUserQuestion
 ---

--- a/plugins/gemini/commands/review.md
+++ b/plugins/gemini/commands/review.md
@@ -1,6 +1,6 @@
 ---
 description: Run a Gemini code review of working-tree or branch changes in this repository
-argument-hint: '[--base <ref>] [--scope <auto|working-tree|branch>] [--wait|--background] [--model auto-gemini-3|flash|flash-lite|<model-id>] [--json]'
+argument-hint: '[--base <ref>] [--scope <auto|working-tree|branch>] [--wait|--background] [--model auto-gemini-3|auto-gemini-2.5|pro|flash|flash-lite|<model-id>] [--json]'
 disable-model-invocation: true
 allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(git:*), AskUserQuestion
 ---

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -66,6 +66,38 @@ const REVIEW_SCHEMA = path.join(ROOT_DIR, "schemas", "review-output.schema.json"
 const DEFAULT_STATUS_WAIT_TIMEOUT_MS = 240000;
 const DEFAULT_STATUS_POLL_INTERVAL_MS = 2000;
 const DEFAULT_MODEL = "auto-gemini-3";
+const MIN_GEMINI_VERSION_FOR_V3_MODELS = [0, 33, 0];
+
+function parseVersionTuple(versionString) {
+  const m = String(versionString ?? "").match(/^(\d+)\.(\d+)\.(\d+)/);
+  return m ? [parseInt(m[1], 10), parseInt(m[2], 10), parseInt(m[3], 10)] : null;
+}
+
+function versionMeetsMinimum(tuple, minimum) {
+  for (let i = 0; i < 3; i++) {
+    if (tuple[i] > minimum[i]) return true;
+    if (tuple[i] < minimum[i]) return false;
+  }
+  return true;
+}
+
+function assertGemini3ModelVersionCompatibility(requestedModel) {
+  const key = requestedModel ?? DEFAULT_MODEL;
+  const resolved = MODEL_ALIASES.get(key) ?? key;
+  if (!/^(auto-gemini-3|gemini-3)/.test(resolved)) return;
+
+  const { available, version } = getGeminiAvailability();
+  if (!available || !version) return;
+
+  const tuple = parseVersionTuple(version);
+  if (tuple && !versionMeetsMinimum(tuple, MIN_GEMINI_VERSION_FOR_V3_MODELS)) {
+    throw new Error(
+      `Model "${key}" (→ "${resolved}") requires @google/gemini-cli >= 0.33.0 but ${version} is installed.\n` +
+      `Upgrade with: npm install -g @google/gemini-cli\n` +
+      `Or use a Gemini 2.5 model: --model auto-gemini-2.5`
+    );
+  }
+}
 
 const MODEL_ALIASES = new Map([
   // Auto-routing aliases (recommended — CLI routes to best available model in tier)
@@ -174,6 +206,7 @@ async function handleReview(argv) {
     return runReviewInBackground(workspaceRoot, options, "review");
   }
 
+  assertGemini3ModelVersionCompatibility(options.model);
   const result = await runAcpReview(cwd, {
     scope: options.scope,
     base: options.base,
@@ -211,6 +244,7 @@ async function handleReviewCommand(argv, { reviewName }) {
     return runReviewInBackground(workspaceRoot, { ...options, focus }, "adversarial-review");
   }
 
+  assertGemini3ModelVersionCompatibility(options.model);
   const result = await runAcpAdversarialReview(cwd, {
     scope: options.scope,
     base: options.base,
@@ -250,6 +284,7 @@ async function handleTask(argv) {
     process.exit(1);
   }
 
+  assertGemini3ModelVersionCompatibility(options.model);
   const model = resolveModel(options.model);
   const approvalMode = options.write ? "auto_edit" : (options["approval-mode"] ?? "default");
 
@@ -550,6 +585,7 @@ async function handleTaskResumeCandidate(argv) {
 // ─── Background Helpers ───────────────────────────────────────────────────────
 
 function runReviewInBackground(workspaceRoot, options, kind) {
+  assertGemini3ModelVersionCompatibility(options.model);
   const job = createTrackedJob({
     workspaceRoot,
     kind,

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -71,7 +71,7 @@ const MODEL_ALIASES = new Map([
   // Auto-routing aliases (recommended — CLI routes to best available model in tier)
   ["auto-gemini-3", "auto-gemini-3"],           // Routes to Gemini 3.1 or 3 models
   ["auto-gemini-2.5", "auto-gemini-2.5"],       // Routes to Gemini 2.5 models
-  ["pro", "auto-gemini-3"],                     // "pro" now routes via auto-gemini-3
+  ["pro", "gemini-3.1-pro-preview"],             // "pro" maps to Gemini 3.1 Pro
   ["flash", "gemini-3-flash-preview"],
   ["flash-lite", "gemini-3.1-flash-lite-preview"],
   // Gemini 3.x concrete model IDs

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -65,10 +65,24 @@ const ROOT_DIR = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 const REVIEW_SCHEMA = path.join(ROOT_DIR, "schemas", "review-output.schema.json");
 const DEFAULT_STATUS_WAIT_TIMEOUT_MS = 240000;
 const DEFAULT_STATUS_POLL_INTERVAL_MS = 2000;
+const DEFAULT_MODEL = "auto-gemini-3";
+
 const MODEL_ALIASES = new Map([
-  ["flash", "gemini-2.5-flash"],
-  ["flash-lite", "gemini-2.5-flash-lite"],
-  ["pro", "gemini-2.5-pro"]
+  // Auto-routing aliases (recommended — CLI routes to best available model in tier)
+  ["auto-gemini-3", "auto-gemini-3"],           // Routes to Gemini 3.1 or 3 models
+  ["auto-gemini-2.5", "auto-gemini-2.5"],       // Routes to Gemini 2.5 models
+  ["pro", "auto-gemini-3"],                     // "pro" now routes via auto-gemini-3
+  ["flash", "gemini-3-flash-preview"],
+  ["flash-lite", "gemini-3.1-flash-lite-preview"],
+  // Gemini 3.x concrete model IDs
+  ["gemini-3.1-pro-preview", "gemini-3.1-pro-preview"],
+  ["gemini-3.1-flash-lite-preview", "gemini-3.1-flash-lite-preview"],
+  ["gemini-3-pro-preview", "gemini-3-pro-preview"],
+  ["gemini-3-flash-preview", "gemini-3-flash-preview"],
+  // Gemini 2.5 concrete model IDs
+  ["gemini-2.5-pro", "gemini-2.5-pro"],
+  ["gemini-2.5-flash", "gemini-2.5-flash"],
+  ["gemini-2.5-flash-lite", "gemini-2.5-flash-lite"]
 ]);
 const STOP_REVIEW_TASK_MARKER = "Run a stop-gate review of the previous Claude turn.";
 
@@ -94,10 +108,8 @@ function resolveCommandCwd(options) {
 }
 
 function resolveModel(value) {
-  if (!value) {
-    return undefined;
-  }
-  return MODEL_ALIASES.get(value) ?? value;
+  const key = value ?? DEFAULT_MODEL;
+  return MODEL_ALIASES.get(key) ?? key;
 }
 
 // ─── Setup ────────────────────────────────────────────────────────────────────

--- a/plugins/gemini/skills/gemini-cli-runtime/SKILL.md
+++ b/plugins/gemini/skills/gemini-cli-runtime/SKILL.md
@@ -38,7 +38,7 @@ The default model is **`auto-gemini-3`**, which routes to the best available Gem
 |-------|-----------|
 | `auto-gemini-3` | Gemini 3.1 or 3 (best available) — **default** |
 | `auto-gemini-2.5` | Gemini 2.5 (stable, production) |
-| `pro` | Same as `auto-gemini-3` |
+| `pro` | `gemini-3.1-pro-preview` (highest capability) |
 | `flash` | `gemini-3-flash-preview` (speed-optimised) |
 | `flash-lite` | `gemini-3.1-flash-lite-preview` (fastest) |
 

--- a/plugins/gemini/skills/gemini-cli-runtime/SKILL.md
+++ b/plugins/gemini/skills/gemini-cli-runtime/SKILL.md
@@ -54,6 +54,8 @@ The default model is **`auto-gemini-3`**, which routes to the best available Gem
 | `gemini-2.5-flash` | Gemini 2.5 |
 | `gemini-2.5-flash-lite` | Gemini 2.5 |
 
+Unlisted model IDs are forwarded as-is to Gemini CLI.
+
 ## Safety Rules
 
 - Exactly one Bash call per rescue invocation.

--- a/plugins/gemini/skills/gemini-cli-runtime/SKILL.md
+++ b/plugins/gemini/skills/gemini-cli-runtime/SKILL.md
@@ -19,7 +19,7 @@ Everything after `--` (or the first non-flag positional) is the task text sent t
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--write` | boolean | false | Enable Gemini to make file changes (sets `--approval-mode auto_edit`) |
-| `--model <name>` | string | (Gemini default) | Model override: `pro`, `flash`, `flash-lite`, or a concrete model name |
+| `--model <name>` | string | `auto-gemini-3` | Model override — see model reference below |
 | `--thinking-budget <n>` | integer | (unset) | Thinking token budget for the model |
 | `--approval-mode <mode>` | string | `default` | One of: `default`, `auto_edit`, `yolo`, `plan` |
 | `--resume-last` | boolean | false | Resume the most recent task thread in this repository |
@@ -27,6 +27,32 @@ Everything after `--` (or the first non-flag positional) is the task text sent t
 | `--wait` | boolean | true | Run in the foreground (default) |
 | `--cwd <path>` | string | `$CLAUDE_PROJECT_DIR` | Working directory override |
 | `--json` | boolean | false | Emit structured JSON instead of rendered markdown |
+
+## Model Reference
+
+The default model is **`auto-gemini-3`**, which routes to the best available Gemini 3.x model.
+
+### Auto-routing aliases (recommended)
+
+| Alias | Routes to |
+|-------|-----------|
+| `auto-gemini-3` | Gemini 3.1 or 3 (best available) — **default** |
+| `auto-gemini-2.5` | Gemini 2.5 (stable, production) |
+| `pro` | Same as `auto-gemini-3` |
+| `flash` | `gemini-3-flash-preview` (speed-optimised) |
+| `flash-lite` | `gemini-3.1-flash-lite-preview` (fastest) |
+
+### Concrete model IDs (pin to specific preview)
+
+| Model ID | Generation |
+|----------|-----------|
+| `gemini-3.1-pro-preview` | Gemini 3.1 |
+| `gemini-3.1-flash-lite-preview` | Gemini 3.1 |
+| `gemini-3-pro-preview` | Gemini 3 |
+| `gemini-3-flash-preview` | Gemini 3 |
+| `gemini-2.5-pro` | Gemini 2.5 |
+| `gemini-2.5-flash` | Gemini 2.5 |
+| `gemini-2.5-flash-lite` | Gemini 2.5 |
 
 ## Safety Rules
 

--- a/plugins/gemini/skills/gemini-prompting/SKILL.md
+++ b/plugins/gemini/skills/gemini-prompting/SKILL.md
@@ -12,18 +12,27 @@ Use this skill only to shape the prompt text before forwarding it to the `gemini
 
 ## Model Selection
 
-The default model is **`auto-gemini-3`**. Only override it when the task has a clear reason to use a different tier.
+The default model is **`auto-gemini-3`**. Only override it when the action type has a clear reason to use a different tier.
 
-| Task type | Recommended model |
-|-----------|-------------------|
-| Complex reasoning, architecture review, deep diagnosis | `auto-gemini-3` (default) or `gemini-3.1-pro-preview` |
-| Standard code tasks, reviews, implementations | `auto-gemini-3` (default — no override needed) |
-| Speed-sensitive tasks, large batch processing | `flash` (`gemini-3-flash-preview`) |
-| Fastest possible, latency-critical | `flash-lite` (`gemini-3.1-flash-lite-preview`) |
-| Production-stable workloads (no preview models) | `auto-gemini-2.5` |
-| Pinned to a specific Gemini 3 preview | `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, etc. |
+### Action-based routing
 
-**Decision rule:** if the user did not specify a model and the task does not clearly demand speed or stability over capability, use the default (`auto-gemini-3`) and omit `--model` entirely.
+| Action type | Examples | Recommended model |
+|-------------|----------|-------------------|
+| Deep reasoning / root-cause diagnosis | Multi-file bug investigation, security audit, architecture review | `pro` (`gemini-3.1-pro-preview`) |
+| Complex implementation | Refactor across many files, design a new subsystem, write an algorithm | `pro` (`gemini-3.1-pro-preview`) |
+| Standard code tasks | Fix a specific bug, implement a well-scoped feature, write tests | `auto-gemini-3` (default — omit `--model`) |
+| Code review / adversarial review | `/gemini:review`, `/gemini:adversarial-review` | `auto-gemini-3` (default — omit `--model`) |
+| Quick lookup / simple edit | One-liner fix, rename, trivial grep-and-replace | `flash` (`gemini-3-flash-preview`) |
+| Latency-critical / high-volume | CI pre-check, tight feedback loop, batch summarisation | `flash-lite` (`gemini-3.1-flash-lite-preview`) |
+| Production-stable (no previews) | Workloads that must avoid preview model churn | `auto-gemini-2.5` |
+
+### Decision rule
+
+1. User explicitly named a model → use it, pass as `--model <name>`.
+2. Task involves deep reasoning, complex multi-file implementation, or security analysis → use `--model pro`.
+3. Task is a standard code fix, feature, or review → omit `--model` (defaults to `auto-gemini-3`).
+4. User asked for speed or the task is trivially small → use `--model flash` or `--model flash-lite`.
+5. User requires preview-free stability → use `--model auto-gemini-2.5`.
 
 ## Gemini Model Characteristics
 

--- a/plugins/gemini/skills/gemini-prompting/SKILL.md
+++ b/plugins/gemini/skills/gemini-prompting/SKILL.md
@@ -10,6 +10,21 @@ user-invocable: false
 
 Use this skill only to shape the prompt text before forwarding it to the `gemini-companion` runtime. Do not use it to do independent work, inspect the repository, or draft solutions.
 
+## Model Selection
+
+The default model is **`auto-gemini-3`**. Only override it when the task has a clear reason to use a different tier.
+
+| Task type | Recommended model |
+|-----------|-------------------|
+| Complex reasoning, architecture review, deep diagnosis | `auto-gemini-3` (default) or `gemini-3.1-pro-preview` |
+| Standard code tasks, reviews, implementations | `auto-gemini-3` (default — no override needed) |
+| Speed-sensitive tasks, large batch processing | `flash` (`gemini-3-flash-preview`) |
+| Fastest possible, latency-critical | `flash-lite` (`gemini-3.1-flash-lite-preview`) |
+| Production-stable workloads (no preview models) | `auto-gemini-2.5` |
+| Pinned to a specific Gemini 3 preview | `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, etc. |
+
+**Decision rule:** if the user did not specify a model and the task does not clearly demand speed or stability over capability, use the default (`auto-gemini-3`) and omit `--model` entirely.
+
 ## Gemini Model Characteristics
 
 - **Long context**: Gemini models handle up to 1M tokens of context. Lean into providing full file contents rather than snippets.

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -55,7 +55,7 @@ test("rescue command uses inline execution without subagent delegation", () => {
   assert.match(rescue, /allowed-tools:\s*Bash\(node:\*\),\s*AskUserQuestion/);
   assert.match(rescue, /--background\|--wait/);
   assert.match(rescue, /--resume\|--fresh/);
-  assert.match(rescue, /--model auto-gemini-3/);
+  assert.match(rescue, /--model auto-gemini-3\|auto-gemini-2\.5\|pro\|flash\|flash-lite\|/);
   assert.match(rescue, /--thinking-budget <number>/);
   assert.match(rescue, /task-resume-candidate --json/);
   assert.match(rescue, /AskUserQuestion/);
@@ -84,6 +84,8 @@ test("rescue command uses inline execution without subagent delegation", () => {
   assert.match(agent, /Do not call `review`, `adversarial-review`, `status`, `result`, or `cancel`/i);
   assert.match(agent, /Leave `--thinking-budget` unset unless the user explicitly requests a specific thinking budget/i);
   assert.match(agent, /The default model is `auto-gemini-3`/i);
+  assert.match(agent, /auto-gemini-2\.5/i);
+  assert.match(agent, /\bpro\b/i);
   assert.match(agent, /If the user asks for `flash`, map that to `--model gemini-3-flash-preview`/i);
   assert.match(agent, /Return the stdout of the `gemini-companion` command exactly as-is/i);
   assert.match(agent, /If the Bash call fails or Gemini cannot be invoked, return nothing/i);

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -55,7 +55,7 @@ test("rescue command uses inline execution without subagent delegation", () => {
   assert.match(rescue, /allowed-tools:\s*Bash\(node:\*\),\s*AskUserQuestion/);
   assert.match(rescue, /--background\|--wait/);
   assert.match(rescue, /--resume\|--fresh/);
-  assert.match(rescue, /--model <name>/);
+  assert.match(rescue, /--model auto-gemini-3/);
   assert.match(rescue, /--thinking-budget <number>/);
   assert.match(rescue, /task-resume-candidate --json/);
   assert.match(rescue, /AskUserQuestion/);
@@ -65,8 +65,8 @@ test("rescue command uses inline execution without subagent delegation", () => {
   assert.match(rescue, /Do not forward them to `task`/i);
   assert.match(rescue, /`--model` and `--thinking-budget` are runtime-selection flags/i);
   assert.match(rescue, /Leave `--thinking-budget` unset unless the user explicitly asks/i);
-  assert.match(rescue, /If they ask for `flash`, map it to `--model gemini-2\.5-flash`/i);
-  assert.match(rescue, /If they ask for `flash-lite`, map it to `--model gemini-2\.5-flash-lite`/i);
+  assert.match(rescue, /The default model is `auto-gemini-3`/i);
+  assert.match(rescue, /auto-gemini-2\.5/i);
   assert.match(rescue, /If the request includes `--resume`, do not ask whether to continue/i);
   assert.match(rescue, /If the request includes `--fresh`, do not ask whether to continue/i);
   assert.match(rescue, /thin forwarding wrapper/i);
@@ -83,8 +83,8 @@ test("rescue command uses inline execution without subagent delegation", () => {
   assert.match(agent, /Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own/i);
   assert.match(agent, /Do not call `review`, `adversarial-review`, `status`, `result`, or `cancel`/i);
   assert.match(agent, /Leave `--thinking-budget` unset unless the user explicitly requests a specific thinking budget/i);
-  assert.match(agent, /Leave model unset by default/i);
-  assert.match(agent, /If the user asks for `flash`, map that to `--model gemini-2\.5-flash`/i);
+  assert.match(agent, /The default model is `auto-gemini-3`/i);
+  assert.match(agent, /If the user asks for `flash`, map that to `--model gemini-3-flash-preview`/i);
   assert.match(agent, /Return the stdout of the `gemini-companion` command exactly as-is/i);
   assert.match(agent, /If the Bash call fails or Gemini cannot be invoked, return nothing/i);
   assert.match(agent, /gemini-prompting/);
@@ -93,7 +93,7 @@ test("rescue command uses inline execution without subagent delegation", () => {
   assert.match(runtimeSkill, /gemini-companion\.mjs" task/);
   assert.match(runtimeSkill, /--resume-last/);
   assert.match(readme, /`gemini:gemini-rescue` subagent/i);
-  assert.match(readme, /if you do not pass `--model`, Gemini chooses its own defaults/i);
+  assert.match(readme, /if you do not pass `--model`, the plugin defaults to `auto-gemini-3`/i);
   assert.match(readme, /### `\/gemini:setup`/);
   assert.match(readme, /### `\/gemini:review`/);
   assert.match(readme, /### `\/gemini:adversarial-review`/);


### PR DESCRIPTION
## Summary

Closes #7.

- **Set `auto-gemini-3` as the default model** — `resolveModel()` in `gemini-companion.mjs` now falls back to `DEFAULT_MODEL` when no `--model` flag is passed, so every invocation (review, task, adversarial-review) targets Gemini 3.x automatically.
- **Expand `MODEL_ALIASES`** to cover all Gemini CLI v0.38.1 model IDs: auto-routing aliases (`auto-gemini-3`, `auto-gemini-2.5`, `pro`, `flash`, `flash-lite`) and concrete Gemini 3.x / 2.5 model IDs. `flash` → `gemini-3-flash-preview`; `flash-lite` → `gemini-3.1-flash-lite-preview`.
- **Add Model Selection guidance to `gemini-prompting` SKILL.md** — decision table so Claude picks the right tier without user input.
- **Add Model Reference to `gemini-cli-runtime` SKILL.md** — alias table with descriptions and the new default documented.
- **Update command argument-hints** (`rescue.md`, `review.md`, `adversarial-review.md`) to show the full alias set.
- **Update `agents/gemini-rescue.md`** forwarding rules to match the new mappings.
- **Update README** model notes to reflect the new default and alias list.
- **Update tests** — all 33 pass.

## Test plan

- [x] `node --test tests/` — 33/33 pass
- [x] No `--model` flag → `resolveModel(undefined)` returns `"auto-gemini-3"`
- [x] `--model flash` → resolves to `gemini-3-flash-preview`
- [x] `--model flash-lite` → resolves to `gemini-3.1-flash-lite-preview`
- [x] `--model pro` → resolves to `auto-gemini-3`
- [x] Unknown alias passthrough still works (e.g. `--model gemini-3.1-pro-preview`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded model selection documentation with new auto-routing aliases and concrete model options.
  * Added model reference guides with task-type-to-model mapping recommendations.

* **Features**
  * Changed default model to `auto-gemini-3` when model option is unspecified.
  * Updated `flash` and `flash-lite` aliases to resolve to newer Gemini 3.x variants.

* **Tests**
  * Updated test assertions to reflect new default model behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->