### PR TITLE
fix: align ACP protocol type map with runtime method name

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -1,0 +1,38 @@
+name: PR Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  delete-branch:
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete merged branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            const defaultBranch = context.payload.repository.default_branch;
+            if (branch === defaultBranch) {
+              core.info(`Refusing to delete default branch: ${branch}`);
+              return;
+            }
+            try {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/${branch}`,
+              });
+              core.info(`Deleted branch: ${branch}`);
+            } catch (error) {
+              if (error.status === 422) {
+                core.info(`Branch already deleted: ${branch}`);
+                return;
+              }
+              throw error;
+            }

--- a/plugins/gemini/scripts/lib/acp-protocol.d.ts
+++ b/plugins/gemini/scripts/lib/acp-protocol.d.ts
@@ -160,7 +160,7 @@ export interface AcpMethodMap {
   authenticate: { params: AuthenticateParams; result: AuthenticateResult };
   "session/new": { params: NewSessionParams; result: NewSessionResult };
   "session/load": { params: LoadSessionParams; result: LoadSessionResult };
-  "session/send_message": { params: PromptParams; result: PromptResult };
+  "session/prompt": { params: PromptParams; result: PromptResult };
   "session/cancel": { params: CancelParams; result: CancelResult };
   "session/set_mode": { params: SetSessionModeParams; result: SetSessionModeResult };
   "session/set_model": { params: SetSessionModelParams; result: SetSessionModelResult };

--- a/tests/acp-protocol.test.mjs
+++ b/tests/acp-protocol.test.mjs
@@ -1,0 +1,54 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const LIB_DIR = path.resolve(__dirname, "..", "plugins", "gemini", "scripts", "lib");
+
+const GEMINI_MJS = fs.readFileSync(path.join(LIB_DIR, "gemini.mjs"), "utf8");
+const ACP_PROTOCOL_DTS = fs.readFileSync(path.join(LIB_DIR, "acp-protocol.d.ts"), "utf8");
+
+test("runtime uses session/prompt as the ACP prompt method (per ACP spec)", () => {
+  const calls = [];
+  const pattern = /client\.request\(\s*"(session\/[a-z_]+)"\s*,\s*\{[^}]*?\bprompt:\s*\[/g;
+  for (const m of GEMINI_MJS.matchAll(pattern)) {
+    calls.push(m[1]);
+  }
+  assert.ok(calls.length > 0, "expected a client.request call with a prompt payload");
+  assert.ok(
+    calls.includes("session/prompt"),
+    `expected a session/prompt call but found: ${calls.join(", ")}`
+  );
+});
+
+test("acp-protocol.d.ts declares session/prompt (not session/send_message)", () => {
+  assert.match(
+    ACP_PROTOCOL_DTS,
+    /"session\/prompt":\s*\{\s*params:\s*PromptParams;\s*result:\s*PromptResult\s*\}/,
+    "acp-protocol.d.ts must declare session/prompt in AcpMethodMap"
+  );
+  assert.doesNotMatch(
+    ACP_PROTOCOL_DTS,
+    /"session\/send_message"/,
+    "acp-protocol.d.ts must not reference the non-canonical session/send_message"
+  );
+});
+
+test("every session/* method called at runtime is declared in acp-protocol.d.ts", () => {
+  const runtimeMethods = new Set();
+  const callPattern = /(?:request|notify)\(\s*"(session\/[a-z_]+)"/g;
+  for (const m of GEMINI_MJS.matchAll(callPattern)) {
+    runtimeMethods.add(m[1]);
+  }
+  assert.ok(runtimeMethods.size > 0, "expected at least one session/* call in gemini.mjs");
+
+  for (const method of runtimeMethods) {
+    assert.match(
+      ACP_PROTOCOL_DTS,
+      new RegExp(`"${method.replace("/", "\\/")}"`),
+      `acp-protocol.d.ts is missing a declaration for ${method}`
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- Fix `acp-protocol.d.ts` to declare `session/prompt` (the canonical ACP method per [the spec](https://agentclientprotocol.com/protocol/prompt-turn)) instead of the non-existent `session/send_message`. Runtime was already correct.
- Add regression tests that verify every `session/*` method called in `gemini.mjs` is declared in the type map and that the prompt method matches the spec.
- Add `.github/workflows/pr-cleanup.yml` that deletes the PR head branch on merge (skips forks and default branch).

Closes #3

## Test plan
- [x] `npm test` — all 39 tests pass (3 new)
- [ ] CI workflow passes on this PR
- [ ] After merge, confirm the pr-cleanup workflow deletes `fix/acp-method-mismatch`