### PR TITLE
chore: remove dead code from stop-review-gate-hook (#4)

### DIFF
--- a/plugins/gemini/scripts/stop-review-gate-hook.mjs
+++ b/plugins/gemini/scripts/stop-review-gate-hook.mjs
@@ -14,11 +14,10 @@
 import fs from "node:fs";
 import process from "node:process";
 
-import { getGeminiAvailability, getGeminiAuthStatus, runAcpPrompt } from "./lib/gemini.mjs";
+import { getGeminiAvailability } from "./lib/gemini.mjs";
 import { getConfig, listJobs } from "./lib/state.mjs";
 import { resolveWorkspaceRoot } from "./lib/workspace.mjs";
 import { loadPrompt } from "./lib/prompts.mjs";
-import { loadBrokerSession } from "./lib/broker-lifecycle.mjs";
 import { runCommand } from "./lib/process.mjs";
 
 function readHookInput() {
@@ -39,21 +38,12 @@ function logNote(note) {
   }
 }
 
-function buildSetupNote(cwd) {
+function buildSetupNote() {
   const { available } = getGeminiAvailability();
   if (!available) {
     return "Gemini CLI is not installed. Run /gemini:setup to install.";
   }
   return null;
-}
-
-function isRunningTask(cwd) {
-  try {
-    const jobs = listJobs(cwd);
-    return jobs.some((j) => j.status === "running" || j.status === "queued");
-  } catch {
-    return false;
-  }
 }
 
 function runStopReview(cwd, input) {
@@ -129,7 +119,7 @@ function main() {
     return;
   }
 
-  const setupNote = buildSetupNote(workspaceRoot);
+  const setupNote = buildSetupNote();
   if (setupNote) {
     logNote(setupNote);
     logNote(runningTaskNote);


### PR DESCRIPTION
## Summary

Addresses #4 — pure code-quality cleanup of `plugins/gemini/scripts/stop-review-gate-hook.mjs`. No behavior change.

- Removed unused `isRunningTask()` helper (its logic is already inlined in `main()` at lines 117–121).
- Trimmed imports from `./lib/gemini.mjs` to just `getGeminiAvailability` (dropped `getGeminiAuthStatus`, `runAcpPrompt`).
- Removed the unused `loadBrokerSession` import from `./lib/broker-lifecycle.mjs`.
- Dropped the unused `cwd` parameter from `buildSetupNote()` and updated its call site.

Closes #4

## Test plan

- [x] `node --check plugins/gemini/scripts/stop-review-gate-hook.mjs` passes.
- [x] Grep confirms zero residual references to the removed identifiers in this file.
- [ ] Hook behavior unchanged — the inline active-jobs block at lines 117–121 (now the only path) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused code dependencies and imports to improve overall code health and maintainability.
  * Simplified internal functions and their signatures for better code organization.
  * Cleaned up and streamlined the codebase to reduce technical debt and establish a foundation for future development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->