### PR TITLE
fix: ACP broker socket permissions

### DIFF
--- a/plugins/gemini/scripts/acp-broker.mjs
+++ b/plugins/gemini/scripts/acp-broker.mjs
@@ -19,6 +19,7 @@ import process from "node:process";
 import { parseArgs } from "./lib/args.mjs";
 import { BROKER_BUSY_RPC_CODE } from "./lib/acp-client.mjs";
 import { parseBrokerEndpoint } from "./lib/broker-endpoint.mjs";
+import { listenOnRestrictedUnixSocket } from "./lib/socket-permissions.mjs";
 import { spawn } from "node:child_process";
 import readline from "node:readline";
 
@@ -339,8 +340,7 @@ async function main() {
 
   if (target.kind === "unix") {
     fs.mkdirSync(path.dirname(target.path), { recursive: true, mode: 0o700 });
-    server.listen(target.path, () => {
-      try { fs.chmodSync(target.path, 0o600); } catch { /* best-effort */ }
+    listenOnRestrictedUnixSocket(server, target.path, () => {
       process.stderr.write(`ACP broker listening on ${target.path}\n`);
     });
   } else {

--- a/plugins/gemini/scripts/lib/socket-permissions.mjs
+++ b/plugins/gemini/scripts/lib/socket-permissions.mjs
@@ -1,0 +1,10 @@
+import process from "node:process";
+
+export function listenOnRestrictedUnixSocket(server, socketPath, onListening) {
+  const oldUmask = process.umask(0o177);
+  try {
+    server.listen(socketPath, onListening);
+  } finally {
+    process.umask(oldUmask);
+  }
+}

--- a/tests/socket-permissions.test.mjs
+++ b/tests/socket-permissions.test.mjs
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import process from "node:process";
+
+import { listenOnRestrictedUnixSocket } from "../plugins/gemini/scripts/lib/socket-permissions.mjs";
+
+test("listenOnRestrictedUnixSocket sets restrictive umask only while listening", () => {
+  const originalUmask = process.umask();
+  let observedUmaskDuringListen = null;
+  let observedPath = null;
+  let observedCallback = null;
+
+  const server = {
+    listen(socketPath, onListening) {
+      observedUmaskDuringListen = process.umask();
+      observedPath = socketPath;
+      observedCallback = onListening;
+    }
+  };
+
+  try {
+    const onListening = () => {};
+    listenOnRestrictedUnixSocket(server, "/tmp/gemini-acp.sock", onListening);
+
+    assert.equal(observedPath, "/tmp/gemini-acp.sock");
+    assert.equal(observedCallback, onListening);
+    assert.equal(observedUmaskDuringListen, 0o177);
+    assert.equal(process.umask(), originalUmask);
+  } finally {
+    process.umask(originalUmask);
+  }
+});

--- a/tests/socket-permissions.test.mjs
+++ b/tests/socket-permissions.test.mjs
@@ -1,5 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import net from "node:net";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import process from "node:process";
 
 import { listenOnRestrictedUnixSocket } from "../plugins/gemini/scripts/lib/socket-permissions.mjs";
@@ -29,4 +33,63 @@ test("listenOnRestrictedUnixSocket sets restrictive umask only while listening",
   } finally {
     process.umask(originalUmask);
   }
+});
+
+test("listenOnRestrictedUnixSocket creates a real unix socket with mode 0o600", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("POSIX-only: umask and unix socket permissions are not meaningful on Windows");
+    return;
+  }
+
+  const sockPath = path.join(
+    os.tmpdir(),
+    `gemini-acp-int-${process.pid}-${Date.now()}.sock`
+  );
+  try { fs.unlinkSync(sockPath); } catch {}
+
+  const originalUmask = process.umask();
+  const server = net.createServer();
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("error", reject);
+      listenOnRestrictedUnixSocket(server, sockPath, () => resolve());
+    });
+
+    const st = fs.statSync(sockPath);
+    const mode = st.mode & 0o777;
+    assert.equal(
+      mode,
+      0o600,
+      `socket ${sockPath} expected mode 0o600, got 0o${mode.toString(8)}`
+    );
+    assert.equal(process.umask(), originalUmask, "umask must be restored after listen()");
+  } finally {
+    await new Promise((resolve) => server.close(() => resolve()));
+    try { fs.unlinkSync(sockPath); } catch {}
+    process.umask(originalUmask);
+  }
+});
+
+test("listenOnRestrictedUnixSocket restores umask even when bind fails asynchronously", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("POSIX-only: umask semantics not applicable on Windows");
+    return;
+  }
+
+  const badPath = "/nonexistent-directory-for-socket-test/should-fail.sock";
+  const originalUmask = process.umask();
+  const server = net.createServer();
+
+  const errPromise = new Promise((resolve) => server.once("error", resolve));
+  listenOnRestrictedUnixSocket(server, badPath, () => {});
+
+  const err = await errPromise;
+  assert.ok(err instanceof Error, "expected an async bind error on invalid path");
+  assert.equal(
+    process.umask(),
+    originalUmask,
+    "umask must be restored even when bind() fails asynchronously"
+  );
+  server.close();
 });


### PR DESCRIPTION
## Summary

- Fixes the ACP broker Unix socket TOCTOU permission race from #5.
- Adds `listenOnRestrictedUnixSocket()` to set `umask(0o177)` around socket creation and restore the previous umask afterward.
- Replaces callback-time `chmodSync(0o600)` with restrictive permissions at socket creation time.
- Adds test coverage for the umask ordering and restoration behavior.

## Validation

- `node --test tests/socket-permissions.test.mjs`
- `npm test` (40/40 passing)

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Unix socket permission handling in the Gemini plugin to enforce stricter access controls, ensuring socket files are created with restricted permissions and proper umask settings are maintained throughout the socket lifecycle.

* **Tests**
  * Added comprehensive test coverage for socket permission management behavior across different scenarios and platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->