### PR TITLE
fix: root workspace path containment

### DIFF
--- a/plugins/gemini/scripts/lib/git.mjs
+++ b/plugins/gemini/scripts/lib/git.mjs
@@ -183,7 +183,8 @@ export function readUntrackedFiles(cwd, files, options = {}) {
       // Verify the resolved path stays inside the workspace.
       const realPath = fs.realpathSync(fullPath);
       const realCwd = fs.realpathSync(cwd);
-      if (!realPath.startsWith(realCwd + path.sep) && realPath !== realCwd) {
+      const workspacePrefix = realCwd.endsWith(path.sep) ? realCwd : realCwd + path.sep;
+      if (!realPath.startsWith(workspacePrefix) && realPath !== realCwd) {
         results.push({ path: file, skipped: "outside workspace" });
         continue;
       }

--- a/plugins/gemini/scripts/lib/git.mjs
+++ b/plugins/gemini/scripts/lib/git.mjs
@@ -159,11 +159,12 @@ export function getWorkingTreeDiff(cwd) {
  *
  * @param {string} cwd
  * @param {string[]} files
- * @param {{ maxBytes?: number }} [options]
+ * @param {{ maxBytes?: number, realpathSync?: typeof fs.realpathSync }} [options]
  * @returns {Array<{ path: string, content: string } | { path: string, skipped: string }>}
  */
 export function readUntrackedFiles(cwd, files, options = {}) {
   const maxBytes = options.maxBytes ?? MAX_UNTRACKED_BYTES;
+  const realpathSync = options.realpathSync ?? fs.realpathSync;
   let totalBytes = 0;
   const results = [];
 
@@ -181,10 +182,14 @@ export function readUntrackedFiles(cwd, files, options = {}) {
         continue;
       }
       // Verify the resolved path stays inside the workspace.
-      const realPath = fs.realpathSync(fullPath);
-      const realCwd = fs.realpathSync(cwd);
-      const workspacePrefix = realCwd.endsWith(path.sep) ? realCwd : realCwd + path.sep;
-      if (!realPath.startsWith(workspacePrefix) && realPath !== realCwd) {
+      const realPath = realpathSync(fullPath);
+      const realCwd = realpathSync(cwd);
+      const relativePath = path.relative(realCwd, realPath);
+      const outsideWorkspace =
+        relativePath === ".." ||
+        relativePath.startsWith(`..${path.sep}`) ||
+        path.isAbsolute(relativePath);
+      if (outsideWorkspace) {
         results.push({ path: file, skipped: "outside workspace" });
         continue;
       }
@@ -212,7 +217,7 @@ export function readUntrackedFiles(cwd, files, options = {}) {
  * Collect complete working-tree context for a code review.
  *
  * @param {string} cwd
- * @param {{ maxInlineFiles?: number, maxInlineDiffBytes?: number }} [options]
+ * @param {{ maxInlineFiles?: number, maxInlineDiffBytes?: number, realpathSync?: typeof fs.realpathSync }} [options]
  * @returns {{ branch: string | null, headSha: string, diff: string, files: { staged: string[], unstaged: string[], untracked: string[] }, untrackedContents: Array<any>, summary: string }}
  */
 export function collectWorkingTreeContext(cwd, options = {}) {
@@ -220,7 +225,9 @@ export function collectWorkingTreeContext(cwd, options = {}) {
   const headSha = getHeadSha(cwd);
   const files = getWorkingTreeFiles(cwd);
   const diff = getWorkingTreeDiff(cwd);
-  const untrackedContents = readUntrackedFiles(cwd, files.untracked);
+  const untrackedContents = readUntrackedFiles(cwd, files.untracked, {
+    realpathSync: options.realpathSync
+  });
 
   const allFiles = listUniqueFiles(files.staged, files.unstaged);
   const summary = buildWorkingTreeSummary(branch, headSha, allFiles, files.untracked);
@@ -291,7 +298,7 @@ export function buildBranchComparison(cwd, baseRef) {
  * Collect git context based on scope (working-tree or branch).
  *
  * @param {string} cwd
- * @param {{ scope?: "auto" | "working-tree" | "branch", base?: string }} [options]
+ * @param {{ scope?: "auto" | "working-tree" | "branch", base?: string, realpathSync?: typeof fs.realpathSync }} [options]
  * @returns {{ scope: string, context: any }}
  */
 const VALID_SCOPES = new Set(["auto", "working-tree", "branch"]);
@@ -319,7 +326,7 @@ export function collectReviewContext(cwd, options = {}) {
     if (hasChanges) {
       return {
         scope: "working-tree",
-        context: collectWorkingTreeContext(cwd)
+        context: collectWorkingTreeContext(cwd, options)
       };
     }
     // Try branch comparison against main/master.
@@ -337,6 +344,6 @@ export function collectReviewContext(cwd, options = {}) {
   // Default to working-tree.
   return {
     scope: "working-tree",
-    context: collectWorkingTreeContext(cwd)
+    context: collectWorkingTreeContext(cwd, options)
   };
 }

--- a/tests/git.test.mjs
+++ b/tests/git.test.mjs
@@ -84,6 +84,41 @@ test("collectReviewContext skips broken untracked symlinks instead of crashing",
   assert.ok(typeof context === "object");
 });
 
+test("collectReviewContext includes untracked files when workspace resolves to filesystem root", () => {
+  const cwd = makeTempDir();
+  initGitRepo(cwd);
+  fs.writeFileSync(path.join(cwd, "app.js"), "console.log('v1');\n");
+  run("git", ["add", "app.js"], { cwd });
+  run("git", ["commit", "-m", "init"], { cwd });
+
+  const file = "notes.txt";
+  const fullPath = path.join(cwd, file);
+  fs.writeFileSync(fullPath, "review me\n");
+
+  const root = path.parse(cwd).root;
+  const originalRealpathSync = fs.realpathSync;
+  fs.realpathSync = (target, options) => {
+    const targetPath = path.resolve(String(target));
+    if (targetPath === path.resolve(cwd)) {
+      return root;
+    }
+    if (targetPath === path.resolve(fullPath)) {
+      return path.join(root, file);
+    }
+    return originalRealpathSync.call(fs, target, options);
+  };
+
+  try {
+    const result = collectReviewContext(cwd, { scope: "working-tree" });
+
+    assert.deepEqual(result.context.untrackedContents, [
+      { path: file, content: "review me\n" }
+    ]);
+  } finally {
+    fs.realpathSync = originalRealpathSync;
+  }
+});
+
 test("collectReviewContext throws on invalid scope value", () => {
   const cwd = makeTempDir();
   initGitRepo(cwd);

--- a/tests/git.test.mjs
+++ b/tests/git.test.mjs
@@ -96,8 +96,9 @@ test("collectReviewContext includes untracked files when workspace resolves to f
   fs.writeFileSync(fullPath, "review me\n");
 
   const root = path.parse(cwd).root;
-  const originalRealpathSync = fs.realpathSync;
-  fs.realpathSync = (target, options) => {
+  const realpathCalls = [];
+  const realpathSync = (target, options) => {
+    realpathCalls.push(path.resolve(String(target)));
     const targetPath = path.resolve(String(target));
     if (targetPath === path.resolve(cwd)) {
       return root;
@@ -105,18 +106,47 @@ test("collectReviewContext includes untracked files when workspace resolves to f
     if (targetPath === path.resolve(fullPath)) {
       return path.join(root, file);
     }
-    return originalRealpathSync.call(fs, target, options);
+    return fs.realpathSync(target, options);
   };
 
-  try {
-    const result = collectReviewContext(cwd, { scope: "working-tree" });
+  const result = collectReviewContext(cwd, { scope: "working-tree", realpathSync });
 
-    assert.deepEqual(result.context.untrackedContents, [
-      { path: file, content: "review me\n" }
-    ]);
-  } finally {
-    fs.realpathSync = originalRealpathSync;
-  }
+  assert.deepEqual(result.context.untrackedContents, [
+    { path: file, content: "review me\n" }
+  ]);
+  assert.deepEqual(realpathCalls, [path.resolve(fullPath), path.resolve(cwd)]);
+});
+
+test("collectReviewContext rejects untracked files that resolve outside the workspace", () => {
+  const cwd = makeTempDir();
+  initGitRepo(cwd);
+  fs.writeFileSync(path.join(cwd, "app.js"), "console.log('v1');\n");
+  run("git", ["add", "app.js"], { cwd });
+  run("git", ["commit", "-m", "init"], { cwd });
+
+  const file = "escape.txt";
+  const fullPath = path.join(cwd, file);
+  fs.writeFileSync(fullPath, "nope\n");
+
+  const root = path.parse(cwd).root;
+  const workspaceRealpath = path.join(root, "workspace");
+  const outsideRealpath = path.join(root, "outside", file);
+  const realpathSync = (target) => {
+    const targetPath = path.resolve(String(target));
+    if (targetPath === path.resolve(cwd)) {
+      return workspaceRealpath;
+    }
+    if (targetPath === path.resolve(fullPath)) {
+      return outsideRealpath;
+    }
+    return fs.realpathSync(target);
+  };
+
+  const result = collectReviewContext(cwd, { scope: "working-tree", realpathSync });
+
+  assert.deepEqual(result.context.untrackedContents, [
+    { path: file, skipped: "outside workspace" }
+  ]);
 });
 
 test("collectReviewContext throws on invalid scope value", () => {


### PR DESCRIPTION
## Summary

- Fix untracked-file containment checks when the workspace realpath is a filesystem root.
- Add a regression test that simulates a root-resolved workspace and verifies untracked file contents are still included.

## Root Cause

`readUntrackedFiles()` built its containment prefix as `realCwd + path.sep`. At filesystem roots, `realCwd` already ends with the separator, so the prefix became `//` on Unix or `C:\\` on Windows and valid root-level files failed `startsWith()`.

## Test Plan

- `node --test tests/git.test.mjs`
- `npm test`

Fixes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation for correctly identifying files outside workspace boundaries.

* **Tests**
  * Added test coverage for untracked file handling in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->