### PR TITLE
feat: stream ACP output, surface thought chunks, add --thinking t-shirt levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,68 @@ When the review gate is enabled, the plugin uses a `Stop` hook to run a targeted
 
 > **Warning:** The review gate can create a long-running Claude/Gemini loop and may drain usage limits quickly. Only enable it when you plan to actively monitor the session.
 
+## Live Progress & Thinking Levels
+
+### Thinking levels
+
+Each task or review accepts `--thinking <off|low|medium|high>` — a t-shirt sized control over how hard Gemini reasons before answering:
+
+| Level | Behavior |
+|-------|----------|
+| `off` | Minimal reasoning. Fastest; clamped to `low` on models that don't support zero thinking. |
+| `low` | Light reasoning — quick tasks, short context. |
+| `medium` *(default)* | Dynamic reasoning — balanced default, matches the model's own heuristics. |
+| `high` | Deep reasoning — use when the task needs careful analysis. |
+
+The level maps to the right underlying Gemini parameter for the selected model (Gemini 3 `thinkingLevel`, Gemini 2.5 `thinkingBudget`). Unknown models emit a one-line note to stderr and pass through unchanged. If the local Gemini CLI does not expose a per-invocation thinking override, the flag is still parsed and validated but emits a one-shot stderr warning so you understand why it has no observable effect — configure `thinkingConfig` at the model-alias level in your Gemini `settings.json` for a persistent setting.
+
+### Live progress in the terminal
+
+Foreground runs emit progress to **stderr** so stdout stays a single final write (safe for `--json`, pipe-friendly for wrappers).
+
+By default, progress uses compact markers:
+
+```
+[session] created
+[tool] read_file
+.....                        (one '.' per model chunk)
+[thinking]                   (one per thought chunk; raw thought text never shown)
+[tool] write_file
+[file] write plugins/x.mjs
+[done] 1.2s | 2 tools | 1 file | 14 chunks | 1 thought
+```
+
+Pass `--stream-output` to upgrade to raw passthrough — every message chunk and every thought chunk is written to stderr as it arrives:
+
+```
+[session] created
+[tool] read_file
+Here's what I found in the file...
+thought: Let me think about the approach.
+[tool] write_file
+```
+
+### Background jobs: `/gemini:status` event tail
+
+For `--background` runs, `/gemini:status` renders the tail of recent events per active job:
+
+```
+Running jobs (1):
+  job_abc123  task  running  2s ago
+    last event: model_text_chunk 85 chars - 200ms ago
+    recent:
+      [phase] session_created          2.1s ago
+      [tool_call] read_file            1.8s ago
+      [model_text_chunk] 140 chars     1.2s ago
+      [model_thought_chunk] 62 chars   900ms ago
+      [model_text_chunk] 85 chars      200ms ago
+    totals: chunks=3  thoughts=1  tools=1  files=0
+```
+
+### Privacy
+
+Raw model prose and raw thought text are **never persisted** to job files or to the status view. Only sanitized metadata (character counts, tool names, file paths) lands in the event log. Raw chunks appear live in stderr only, and only when you opt in with `--stream-output`.
+
 ## Typical Flows
 
 ### Review Before Shipping

--- a/README.md
+++ b/README.md
@@ -246,16 +246,16 @@ When the review gate is enabled, the plugin uses a `Stop` hook to run a targeted
 
 ### Thinking levels
 
-Each task or review accepts `--thinking <off|low|medium|high>` — a t-shirt sized control over how hard Gemini reasons before answering:
+Each task or review accepts `--thinking <off|low|medium|high>` — a t-shirt-sized request for the reasoning level:
 
 | Level | Behavior |
 |-------|----------|
-| `off` | Minimal reasoning. Fastest; clamped to `low` on models that don't support zero thinking. |
+| `off` | Minimal reasoning request. Fastest; clamped to `low` on models that don't support zero thinking. |
 | `low` | Light reasoning — quick tasks, short context. |
 | `medium` *(default)* | Dynamic reasoning — balanced default, matches the model's own heuristics. |
 | `high` | Deep reasoning — use when the task needs careful analysis. |
 
-The level maps to the right underlying Gemini parameter for the selected model (Gemini 3 `thinkingLevel`, Gemini 2.5 `thinkingBudget`). Unknown models emit a one-line note to stderr and pass through unchanged. If the local Gemini CLI does not expose a per-invocation thinking override, the flag is still parsed and validated but emits a one-shot stderr warning so you understand why it has no observable effect — configure `thinkingConfig` at the model-alias level in your Gemini `settings.json` for a persistent setting.
+The level maps to the right underlying Gemini parameter for the selected model (Gemini 3 `thinkingLevel`, Gemini 2.5 `thinkingBudget`). Unknown models emit a one-line note to stderr and pass through unchanged. The local Gemini CLI does not expose a per-invocation thinking override yet, so the flag is parsed and validated but emits a one-shot stderr warning and falls back to the CLI's default reasoning. Configure `thinkingConfig` at the model-alias level in your Gemini `settings.json` for a persistent setting that takes effect today.
 
 ### Live progress in the terminal
 
@@ -263,7 +263,7 @@ Foreground runs emit progress to **stderr** so stdout stays a single final write
 
 By default, progress uses compact markers:
 
-```
+```text
 [session] created
 [tool] read_file
 .....                        (one '.' per model chunk)
@@ -275,7 +275,7 @@ By default, progress uses compact markers:
 
 Pass `--stream-output` to upgrade to raw passthrough — every message chunk and every thought chunk is written to stderr as it arrives:
 
-```
+```text
 [session] created
 [tool] read_file
 Here's what I found in the file...
@@ -287,7 +287,7 @@ thought: Let me think about the approach.
 
 For `--background` runs, `/gemini:status` renders the tail of recent events per active job:
 
-```
+```text
 Running jobs (1):
   job_abc123  task  running  2s ago
     last event: model_text_chunk 85 chars - 200ms ago

--- a/plugins/gemini/agents/gemini-rescue.md
+++ b/plugins/gemini/agents/gemini-rescue.md
@@ -26,7 +26,8 @@ Forwarding rules:
 - Do not use that skill to inspect the repository, reason through the problem yourself, draft a solution, or do any independent work beyond shaping the forwarded prompt text.
 - Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own.
 - Do not call `review`, `adversarial-review`, `status`, `result`, or `cancel`. This subagent only forwards to `task`.
-- Leave `--thinking-budget` unset unless the user explicitly requests a specific thinking budget.
+- Leave `--thinking` unset unless the user explicitly requests a specific thinking level. The runtime defaults to medium.
+- Add `--stream-output` only when the user explicitly asks to see the model's raw output stream; default is compact stderr markers.
 - The default model is `auto-gemini-3`. Leave `--model` unset unless the user explicitly asks for a different model — the runtime applies the default automatically.
 - If the user specifies a model, pass it as `--model <name>`. The runtime forwards the value to Gemini CLI; any model ID supported by Gemini CLI is valid. Common values include:
   - Shorthand aliases: `pro` (→ `gemini-3.1-pro-preview`), `flash` (→ `gemini-3-flash-preview`), `flash-lite` (→ `gemini-3.1-flash-lite-preview`), `auto-gemini-3`, `auto-gemini-2.5`
@@ -35,7 +36,7 @@ Forwarding rules:
 - If the user asks for `pro`, map that to `--model gemini-3.1-pro-preview`.
 - If the user asks for `flash`, map that to `--model gemini-3-flash-preview`.
 - If the user asks for `flash-lite`, map that to `--model gemini-3.1-flash-lite-preview`.
-- Treat `--thinking-budget <value>` and `--model <value>` as runtime controls and do not include them in the task text you pass through.
+- Treat `--thinking <value>`, `--stream-output`, and `--model <value>` as runtime controls and do not include them in the task text you pass through.
 - Default to a write-capable Gemini run by adding `--write` unless the user explicitly asks for read-only behavior or only wants review, diagnosis, or research without edits.
 - Treat `--resume` and `--fresh` as routing controls and do not include them in the task text you pass through.
 - `--resume` means add `--resume-last`.

--- a/plugins/gemini/agents/gemini-rescue.md
+++ b/plugins/gemini/agents/gemini-rescue.md
@@ -26,7 +26,7 @@ Forwarding rules:
 - Do not use that skill to inspect the repository, reason through the problem yourself, draft a solution, or do any independent work beyond shaping the forwarded prompt text.
 - Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own.
 - Do not call `review`, `adversarial-review`, `status`, `result`, or `cancel`. This subagent only forwards to `task`.
-- Leave `--thinking` unset unless the user explicitly requests a specific thinking level. The runtime defaults to medium.
+- Leave `--thinking` unset unless the user explicitly requests a specific thinking level. The runtime defaults to medium. The local Gemini CLI does not expose a per-invocation thinking override yet, so the companion emits a one-shot warning and falls back to the CLI's default reasoning unless `thinkingConfig` is set persistently in Gemini `settings.json`.
 - Add `--stream-output` only when the user explicitly asks to see the model's raw output stream; default is compact stderr markers.
 - The default model is `auto-gemini-3`. Leave `--model` unset unless the user explicitly asks for a different model — the runtime applies the default automatically.
 - If the user specifies a model, pass it as `--model <name>`. The runtime forwards the value to Gemini CLI; any model ID supported by Gemini CLI is valid. Common values include:

--- a/plugins/gemini/commands/rescue.md
+++ b/plugins/gemini/commands/rescue.md
@@ -17,7 +17,7 @@ Execution mode:
 - If neither flag is present, default to foreground.
 - `--background` and `--wait` are execution flags for Claude Code. Do not forward them to `task`, and do not treat them as part of the natural-language task text.
 - `--model`, `--thinking`, and `--stream-output` are runtime-selection flags. Preserve them for the forwarded `task` call, but do not treat them as part of the natural-language task text.
-- `--thinking` accepts `off`, `low`, `medium` (default), or `high`. Omit when the user has not asked for a specific thinking level; pass the user's chosen level otherwise. If the user asks you to "think harder" on a complex task, pass `--thinking high`.
+- `--thinking` accepts `off`, `low`, `medium` (default), or `high`. Omit when the user has not asked for a specific thinking level; pass the user's chosen level otherwise. The local Gemini CLI does not expose a per-invocation thinking override yet, so the companion emits a one-shot warning and falls back to the CLI's default reasoning unless `thinkingConfig` is set persistently in Gemini `settings.json`.
 - Add `--stream-output` only when the user explicitly asks to see the model's raw output stream. Default (no flag) uses compact stderr markers.
 - If the request includes `--resume`, do not ask whether to continue. The user already chose.
 - If the request includes `--fresh`, do not ask whether to continue. The user already chose.
@@ -41,7 +41,7 @@ Invocation:
 
 - Use exactly one `Bash` call to invoke `node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" task ...` and return that command's stdout as-is.
 - Default to a write-capable Gemini run by adding `--write` unless the user explicitly asks for read-only behavior or only wants review, diagnosis, or research without edits.
-- Leave `--thinking` unset unless the user explicitly asks for a specific thinking level. The runtime defaults to medium.
+- Leave `--thinking` unset unless the user explicitly asks for a specific thinking level. The runtime defaults to medium, and the current CLI only applies thinking changes from persistent `settings.json` config.
 - The default model is `auto-gemini-3`. Leave `--model` unset unless the user explicitly names a different model — the runtime applies the default automatically.
 - If the user specifies a model name, pass it as `--model <name>`. Accepted values:
   - Shorthand aliases: `pro` (→ `gemini-3.1-pro-preview`), `flash` (→ `gemini-3-flash-preview`), `flash-lite` (→ `gemini-3.1-flash-lite-preview`), `auto-gemini-3`, `auto-gemini-2.5`

--- a/plugins/gemini/commands/rescue.md
+++ b/plugins/gemini/commands/rescue.md
@@ -1,6 +1,6 @@
 ---
 description: Delegate a task to Gemini for debugging, implementation, or deeper investigation
-argument-hint: "[--background|--wait] [--resume|--fresh] [--model auto-gemini-3|auto-gemini-2.5|pro|flash|flash-lite|<concrete-model-id>] [--thinking-budget <number>] [--approval-mode <mode>] [what Gemini should investigate, solve, or continue]"
+argument-hint: "[--background|--wait] [--resume|--fresh] [--model auto-gemini-3|auto-gemini-2.5|pro|flash|flash-lite|<concrete-model-id>] [--thinking <off|low|medium|high>] [--stream-output] [--approval-mode <mode>] [what Gemini should investigate, solve, or continue]"
 context: fork
 allowed-tools: Bash(node:*), AskUserQuestion
 ---
@@ -16,7 +16,9 @@ Execution mode:
 - If the request includes `--wait`, run in the foreground.
 - If neither flag is present, default to foreground.
 - `--background` and `--wait` are execution flags for Claude Code. Do not forward them to `task`, and do not treat them as part of the natural-language task text.
-- `--model` and `--thinking-budget` are runtime-selection flags. Preserve them for the forwarded `task` call, but do not treat them as part of the natural-language task text.
+- `--model`, `--thinking`, and `--stream-output` are runtime-selection flags. Preserve them for the forwarded `task` call, but do not treat them as part of the natural-language task text.
+- `--thinking` accepts `off`, `low`, `medium` (default), or `high`. Omit when the user has not asked for a specific thinking level; pass the user's chosen level otherwise. If the user asks you to "think harder" on a complex task, pass `--thinking high`.
+- Add `--stream-output` only when the user explicitly asks to see the model's raw output stream. Default (no flag) uses compact stderr markers.
 - If the request includes `--resume`, do not ask whether to continue. The user already chose.
 - If the request includes `--fresh`, do not ask whether to continue. The user already chose.
 - Otherwise, before starting Gemini, check for a resumable rescue thread from this Claude session by running:
@@ -39,7 +41,7 @@ Invocation:
 
 - Use exactly one `Bash` call to invoke `node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" task ...` and return that command's stdout as-is.
 - Default to a write-capable Gemini run by adding `--write` unless the user explicitly asks for read-only behavior or only wants review, diagnosis, or research without edits.
-- Leave `--thinking-budget` unset unless the user explicitly asks for a specific thinking budget.
+- Leave `--thinking` unset unless the user explicitly asks for a specific thinking level. The runtime defaults to medium.
 - The default model is `auto-gemini-3`. Leave `--model` unset unless the user explicitly names a different model — the runtime applies the default automatically.
 - If the user specifies a model name, pass it as `--model <name>`. Accepted values:
   - Shorthand aliases: `pro` (→ `gemini-3.1-pro-preview`), `flash` (→ `gemini-3-flash-preview`), `flash-lite` (→ `gemini-3.1-flash-lite-preview`), `auto-gemini-3`, `auto-gemini-2.5`

--- a/plugins/gemini/commands/review.md
+++ b/plugins/gemini/commands/review.md
@@ -1,6 +1,6 @@
 ---
 description: Run a Gemini code review of working-tree or branch changes in this repository
-argument-hint: '[--base <ref>] [--scope <auto|working-tree|branch>] [--wait|--background] [--model auto-gemini-3|auto-gemini-2.5|pro|flash|flash-lite|<model-id>] [--json]'
+argument-hint: '[--base <ref>] [--scope <auto|working-tree|branch>] [--wait|--background] [--model auto-gemini-3|auto-gemini-2.5|pro|flash|flash-lite|<model-id>] [--thinking <off|low|medium|high>] [--stream-output] [--json]'
 disable-model-invocation: true
 allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(git:*), AskUserQuestion
 ---
@@ -8,6 +8,10 @@ allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(git:*), AskUserQuestion
 Run:
 
 !`node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" review "$ARGUMENTS"`
+
+Flags:
+- `--thinking <off|low|medium|high>` controls how hard Gemini reasons before answering (default: medium). Pass `high` for deeper analysis, `low` for quick passes.
+- `--stream-output` streams raw model and thought chunks to stderr during the review. Without it, progress is shown as compact markers.
 
 Output rules:
 - Present the review output to the user exactly as returned.

--- a/plugins/gemini/commands/review.md
+++ b/plugins/gemini/commands/review.md
@@ -10,7 +10,7 @@ Run:
 !`node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" review "$ARGUMENTS"`
 
 Flags:
-- `--thinking <off|low|medium|high>` controls how hard Gemini reasons before answering (default: medium). Pass `high` for deeper analysis, `low` for quick passes.
+- `--thinking <off|low|medium|high>` selects a requested reasoning level (default: medium). The local Gemini CLI does not expose a per-invocation thinking override yet; the companion parses and validates the flag, emits a one-shot warning, and falls back to the CLI's default reasoning. Configure `thinkingConfig` in Gemini `settings.json` for a persistent setting that takes effect today.
 - `--stream-output` streams raw model and thought chunks to stderr during the review. Without it, progress is shown as compact markers.
 
 Output rules:

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -230,7 +230,8 @@ async function handleReview(argv) {
     base: options.base,
     model: resolveModel(options.model),
     thinking,
-    onStream: streamHandler
+    onStream: streamHandler,
+    streamThoughtText: Boolean(options["stream-output"])
   });
 
   if (result.error) {
@@ -288,7 +289,8 @@ async function handleReviewCommand(argv, { reviewName }) {
     focus,
     schemaPath: REVIEW_SCHEMA,
     thinking,
-    onStream: streamHandler
+    onStream: streamHandler,
+    streamThoughtText: Boolean(options["stream-output"])
   });
 
   if (result.error) {
@@ -385,7 +387,8 @@ async function handleTask(argv) {
         approvalMode,
         sessionId,
         thinking,
-        onStream: streamHandler
+        onStream: streamHandler,
+        streamThoughtText: Boolean(options["stream-output"])
       });
 
       streamHandler({
@@ -394,7 +397,7 @@ async function handleTask(argv) {
           tools: result.toolCalls?.length ?? 0,
           files: result.fileChanges?.length ?? 0,
           chunks: 0,
-          thoughts: result.thoughtText ? 1 : 0,
+          thoughts: result.thoughtCount ?? 0,
           elapsedMs: Date.now() - startTime
         }
       });

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -146,6 +146,26 @@ function resolveModel(value) {
   return MODEL_ALIASES.get(key) ?? key;
 }
 
+function resolveThinkingOption(options) {
+  if (options.thinking === undefined) {
+    return undefined;
+  }
+  if (!THINKING_LEVELS.includes(options.thinking)) {
+    process.stderr.write(`Error: invalid --thinking value: ${options.thinking}. Expected one of ${THINKING_LEVELS.join(", ")}.\n`);
+    printUsage();
+    process.exit(1);
+  }
+  return options.thinking;
+}
+
+function createStderrStreamHandler(options) {
+  return createStreamHandler({
+    mode: options["stream-output"] ? "passthrough" : "markers",
+    json: Boolean(options.json),
+    writer: (s) => process.stderr.write(s)
+  });
+}
+
 // ─── Setup ────────────────────────────────────────────────────────────────────
 
 async function handleSetup(argv) {
@@ -201,21 +221,8 @@ async function handleReview(argv) {
     booleanOptions: ["json", "wait", "background", "stream-output"]
   });
 
-  let thinking;
-  if (options.thinking !== undefined) {
-    if (!THINKING_LEVELS.includes(options.thinking)) {
-      process.stderr.write(`Error: invalid --thinking value: ${options.thinking}. Expected one of ${THINKING_LEVELS.join(", ")}.\n`);
-      printUsage();
-      process.exit(1);
-    }
-    thinking = options.thinking;
-  }
-
-  const streamHandler = createStreamHandler({
-    mode: options["stream-output"] ? "passthrough" : "markers",
-    json: Boolean(options.json),
-    writer: (s) => process.stderr.write(s)
-  });
+  const thinking = resolveThinkingOption(options);
+  const streamHandler = createStderrStreamHandler(options);
 
   const cwd = resolveCommandCwd(options);
   const workspaceRoot = resolveWorkspaceRoot(cwd);
@@ -257,21 +264,8 @@ async function handleReviewCommand(argv, { reviewName }) {
     booleanOptions: ["json", "wait", "background", "stream-output"]
   });
 
-  let thinking;
-  if (options.thinking !== undefined) {
-    if (!THINKING_LEVELS.includes(options.thinking)) {
-      process.stderr.write(`Error: invalid --thinking value: ${options.thinking}. Expected one of ${THINKING_LEVELS.join(", ")}.\n`);
-      printUsage();
-      process.exit(1);
-    }
-    thinking = options.thinking;
-  }
-
-  const streamHandler = createStreamHandler({
-    mode: options["stream-output"] ? "passthrough" : "markers",
-    json: Boolean(options.json),
-    writer: (s) => process.stderr.write(s)
-  });
+  const thinking = resolveThinkingOption(options);
+  const streamHandler = createStderrStreamHandler(options);
 
   const cwd = resolveCommandCwd(options);
   const workspaceRoot = resolveWorkspaceRoot(cwd);
@@ -318,21 +312,8 @@ async function handleTask(argv) {
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const taskText = positionals.join(" ").trim();
 
-  let thinking;
-  if (options.thinking !== undefined) {
-    if (!THINKING_LEVELS.includes(options.thinking)) {
-      process.stderr.write(`Error: invalid --thinking value: ${options.thinking}. Expected one of ${THINKING_LEVELS.join(", ")}.\n`);
-      printUsage();
-      process.exit(1);
-    }
-    thinking = options.thinking;
-  }
-
-  const streamHandler = createStreamHandler({
-    mode: options["stream-output"] ? "passthrough" : "markers",
-    json: Boolean(options.json),
-    writer: (s) => process.stderr.write(s)
-  });
+  const thinking = resolveThinkingOption(options);
+  const streamHandler = createStderrStreamHandler(options);
 
   if (!taskText && !options["resume-last"]) {
     process.stderr.write("Error: No task text provided.\n");
@@ -391,20 +372,20 @@ async function handleTask(argv) {
         streamThoughtText: Boolean(options["stream-output"])
       });
 
+      if (result.error) {
+        throw result.error;
+      }
+
       streamHandler({
         type: "done",
         stats: {
           tools: result.toolCalls?.length ?? 0,
           files: result.fileChanges?.length ?? 0,
-          chunks: 0,
+          chunks: result.chunkCount ?? 0,
           thoughts: result.thoughtCount ?? 0,
           elapsedMs: Date.now() - startTime
         }
       });
-
-      if (result.error) {
-        throw result.error;
-      }
 
       const rendered = result.text;
       const summary = rendered.slice(0, 120).replace(/\n/g, " ").trim();

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -60,6 +60,8 @@ import {
   renderSingleJobStatus,
   renderStatusSnapshot
 } from "./lib/render.mjs";
+import { THINKING_LEVELS } from "./lib/thinking.mjs";
+import { createStreamHandler } from "./lib/stream-output.mjs";
 
 const ROOT_DIR = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 const REVIEW_SCHEMA = path.join(ROOT_DIR, "schemas", "review-output.schema.json");
@@ -123,9 +125,9 @@ function printUsage() {
     [
       "Usage:",
       "  node scripts/gemini-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]",
-      "  node scripts/gemini-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>]",
-      "  node scripts/gemini-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [--model <name>] [focus text...]",
-      "  node scripts/gemini-companion.mjs task [--write] [--model <name>] [--approval-mode <mode>] [--background|--wait] [--resume-last] [--json] -- <prompt>",
+      "  node scripts/gemini-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [--thinking <off|low|medium|high>] [--stream-output]",
+      "  node scripts/gemini-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [--model <name>] [--thinking <off|low|medium|high>] [--stream-output] [focus text...]",
+      "  node scripts/gemini-companion.mjs task [--write] [--model <name>] [--thinking <off|low|medium|high>] [--approval-mode <mode>] [--stream-output] [--background|--wait] [--resume-last] [--json] -- <prompt>",
       "  node scripts/gemini-companion.mjs task-worker <job-id>",
       "  node scripts/gemini-companion.mjs status [job-id] [--wait] [--timeout-ms <ms>] [--all] [--json]",
       "  node scripts/gemini-companion.mjs result [job-id] [--json]",
@@ -195,22 +197,40 @@ async function handleSetup(argv) {
 
 async function handleReview(argv) {
   const { options } = parseCommandInput(argv, {
-    valueOptions: ["base", "scope", "model", "cwd"],
-    booleanOptions: ["json", "wait", "background"]
+    valueOptions: ["base", "scope", "model", "cwd", "thinking"],
+    booleanOptions: ["json", "wait", "background", "stream-output"]
+  });
+
+  let thinking;
+  if (options.thinking !== undefined) {
+    if (!THINKING_LEVELS.includes(options.thinking)) {
+      process.stderr.write(`Error: invalid --thinking value: ${options.thinking}. Expected one of ${THINKING_LEVELS.join(", ")}.\n`);
+      printUsage();
+      process.exit(1);
+    }
+    thinking = options.thinking;
+  }
+
+  const streamHandler = createStreamHandler({
+    mode: options["stream-output"] ? "passthrough" : "markers",
+    json: Boolean(options.json),
+    writer: (s) => process.stderr.write(s)
   });
 
   const cwd = resolveCommandCwd(options);
   const workspaceRoot = resolveWorkspaceRoot(cwd);
 
   if (options.background) {
-    return runReviewInBackground(workspaceRoot, options, "review");
+    return runReviewInBackground(workspaceRoot, { ...options, thinking }, "review");
   }
 
   assertGemini3ModelVersionCompatibility(options.model);
   const result = await runAcpReview(cwd, {
     scope: options.scope,
     base: options.base,
-    model: resolveModel(options.model)
+    model: resolveModel(options.model),
+    thinking,
+    onStream: streamHandler
   });
 
   if (result.error) {
@@ -232,8 +252,24 @@ async function handleReview(argv) {
 
 async function handleReviewCommand(argv, { reviewName }) {
   const { options, positionals } = parseCommandInput(argv, {
-    valueOptions: ["base", "scope", "model", "cwd"],
-    booleanOptions: ["json", "wait", "background"]
+    valueOptions: ["base", "scope", "model", "cwd", "thinking"],
+    booleanOptions: ["json", "wait", "background", "stream-output"]
+  });
+
+  let thinking;
+  if (options.thinking !== undefined) {
+    if (!THINKING_LEVELS.includes(options.thinking)) {
+      process.stderr.write(`Error: invalid --thinking value: ${options.thinking}. Expected one of ${THINKING_LEVELS.join(", ")}.\n`);
+      printUsage();
+      process.exit(1);
+    }
+    thinking = options.thinking;
+  }
+
+  const streamHandler = createStreamHandler({
+    mode: options["stream-output"] ? "passthrough" : "markers",
+    json: Boolean(options.json),
+    writer: (s) => process.stderr.write(s)
   });
 
   const cwd = resolveCommandCwd(options);
@@ -241,7 +277,7 @@ async function handleReviewCommand(argv, { reviewName }) {
   const focus = positionals.join(" ").trim() || undefined;
 
   if (options.background) {
-    return runReviewInBackground(workspaceRoot, { ...options, focus }, "adversarial-review");
+    return runReviewInBackground(workspaceRoot, { ...options, focus, thinking }, "adversarial-review");
   }
 
   assertGemini3ModelVersionCompatibility(options.model);
@@ -250,7 +286,9 @@ async function handleReviewCommand(argv, { reviewName }) {
     base: options.base,
     model: resolveModel(options.model),
     focus,
-    schemaPath: REVIEW_SCHEMA
+    schemaPath: REVIEW_SCHEMA,
+    thinking,
+    onStream: streamHandler
   });
 
   if (result.error) {
@@ -270,13 +308,29 @@ async function handleReviewCommand(argv, { reviewName }) {
 
 async function handleTask(argv) {
   const { options, positionals } = parseCommandInput(argv, {
-    valueOptions: ["model", "approval-mode", "cwd"],
-    booleanOptions: ["json", "write", "background", "wait", "resume-last"]
+    valueOptions: ["model", "approval-mode", "cwd", "thinking"],
+    booleanOptions: ["json", "write", "background", "wait", "resume-last", "stream-output"]
   });
 
   const cwd = resolveCommandCwd(options);
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const taskText = positionals.join(" ").trim();
+
+  let thinking;
+  if (options.thinking !== undefined) {
+    if (!THINKING_LEVELS.includes(options.thinking)) {
+      process.stderr.write(`Error: invalid --thinking value: ${options.thinking}. Expected one of ${THINKING_LEVELS.join(", ")}.\n`);
+      printUsage();
+      process.exit(1);
+    }
+    thinking = options.thinking;
+  }
+
+  const streamHandler = createStreamHandler({
+    mode: options["stream-output"] ? "passthrough" : "markers",
+    json: Boolean(options.json),
+    writer: (s) => process.stderr.write(s)
+  });
 
   if (!taskText && !options["resume-last"]) {
     process.stderr.write("Error: No task text provided.\n");
@@ -307,6 +361,7 @@ async function handleTask(argv) {
       model,
       approvalMode,
       sessionId,
+      thinking,
       json: options.json
     });
   }
@@ -324,10 +379,24 @@ async function handleTask(argv) {
     const execution = await runTrackedJob(job, async () => {
       await updateJobPhase(workspaceRoot, job.id, "running");
 
+      const startTime = Date.now();
       const result = await runAcpPrompt(cwd, prompt, {
         model,
         approvalMode,
-        sessionId
+        sessionId,
+        thinking,
+        onStream: streamHandler
+      });
+
+      streamHandler({
+        type: "done",
+        stats: {
+          tools: result.toolCalls?.length ?? 0,
+          files: result.fileChanges?.length ?? 0,
+          chunks: 0,
+          thoughts: result.thoughtText ? 1 : 0,
+          elapsedMs: Date.now() - startTime
+        }
       });
 
       if (result.error) {
@@ -395,6 +464,7 @@ async function handleTaskWorker(argv) {
           scope: request.scope,
           base: request.base,
           model: request.model,
+          thinking: request.thinking,
           jobObserver
         });
       } else if (jobKind === "adversarial-review") {
@@ -403,6 +473,7 @@ async function handleTaskWorker(argv) {
           base: request.base,
           model: request.model,
           focus: request.focus,
+          thinking: request.thinking,
           jobObserver
         });
       } else {
@@ -410,6 +481,7 @@ async function handleTaskWorker(argv) {
           model: request.model,
           approvalMode: request.approvalMode ?? "default",
           sessionId: request.sessionId,
+          thinking: request.thinking,
           jobObserver
         });
       }
@@ -597,7 +669,8 @@ async function runReviewInBackground(workspaceRoot, options, kind) {
       scope: options.scope,
       base: options.base,
       model: resolveModel(options.model),
-      focus: options.focus
+      focus: options.focus,
+      thinking: options.thinking
     }
   });
 

--- a/plugins/gemini/scripts/lib/acp-protocol.d.ts
+++ b/plugins/gemini/scripts/lib/acp-protocol.d.ts
@@ -147,11 +147,70 @@ export interface BrokerShutdownResult {
 
 // --- ACP Notification Types ---
 
-export type AcpNotification =
-  | { method: "progress"; params: { text: string; phase?: string } }
-  | { method: "toolCall"; params: ToolCallRecord }
-  | { method: "fileChange"; params: FileChangeRecord }
-  | { method: "error"; params: { message: string; code?: number } };
+export interface AgentMessageChunkContent {
+  type: "text";
+  text: string;
+}
+
+export interface AgentThoughtChunkContent {
+  type: "text";
+  text: string;
+}
+
+export interface AgentMessageChunkUpdate {
+  sessionUpdate: "agent_message_chunk";
+  content: AgentMessageChunkContent;
+}
+
+export interface AgentThoughtChunkUpdate {
+  sessionUpdate: "agent_thought_chunk";
+  content: AgentThoughtChunkContent;
+}
+
+export interface ToolCallUpdate {
+  sessionUpdate: "tool_call";
+  toolName?: string;
+  name?: string;
+  arguments?: Record<string, unknown>;
+  input?: Record<string, unknown>;
+  result?: string;
+}
+
+export interface FileChangeUpdate {
+  sessionUpdate: "file_change";
+  path: string;
+  action: string;
+}
+
+export interface OtherSessionUpdate {
+  sessionUpdate: string;
+  [key: string]: unknown;
+}
+
+export type SessionUpdate =
+  | AgentMessageChunkUpdate
+  | AgentThoughtChunkUpdate
+  | ToolCallUpdate
+  | FileChangeUpdate
+  | OtherSessionUpdate;
+
+export interface SessionUpdateNotification {
+  method: "session/update";
+  params: {
+    sessionId: string;
+    update: SessionUpdate;
+  };
+}
+
+export interface BrokerDiagnosticNotification {
+  method: "broker/diagnostic";
+  params: {
+    source?: string;
+    message: string;
+  };
+}
+
+export type AcpNotification = SessionUpdateNotification | BrokerDiagnosticNotification;
 
 // --- Method Map ---
 

--- a/plugins/gemini/scripts/lib/acp-protocol.d.ts
+++ b/plugins/gemini/scripts/lib/acp-protocol.d.ts
@@ -147,24 +147,19 @@ export interface BrokerShutdownResult {
 
 // --- ACP Notification Types ---
 
-export interface AgentMessageChunkContent {
-  type: "text";
-  text: string;
-}
-
-export interface AgentThoughtChunkContent {
+export interface AgentChunkContent {
   type: "text";
   text: string;
 }
 
 export interface AgentMessageChunkUpdate {
   sessionUpdate: "agent_message_chunk";
-  content: AgentMessageChunkContent;
+  content: AgentChunkContent;
 }
 
 export interface AgentThoughtChunkUpdate {
   sessionUpdate: "agent_thought_chunk";
-  content: AgentThoughtChunkContent;
+  content: AgentChunkContent;
 }
 
 export interface ToolCallUpdate {
@@ -179,7 +174,7 @@ export interface ToolCallUpdate {
 export interface FileChangeUpdate {
   sessionUpdate: "file_change";
   path: string;
-  action: string;
+  action: "create" | "modify" | "delete";
 }
 
 export interface OtherSessionUpdate {

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -16,6 +16,8 @@ import { loadPrompt } from "./prompts.mjs";
 import { recordJobEvent } from "./job-observability.mjs";
 import { resolveThinkingConfig } from "./thinking.mjs";
 
+let thinkingWarned = false;
+
 /**
  * Convert an ACP session/update notification into a job-observability event.
  * Returns null when the notification is not a session update.
@@ -116,6 +118,23 @@ function buildFileStreamEvent(update) {
   };
 }
 
+function emitThinkingWarningIfNew(writer = (s) => process.stderr.write(s)) {
+  if (thinkingWarned) {
+    return;
+  }
+  writer(
+    "Warning: --thinking is parsed but not delivered to the running Gemini CLI. " +
+    "Configure thinkingConfig at the model-alias level in your Gemini settings.json " +
+    "for a persistent setting. See " +
+    "https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/generation-settings.md\n"
+  );
+  thinkingWarned = true;
+}
+
+function resetThinkingWarning() {
+  thinkingWarned = false;
+}
+
 /**
  * Escape content embedded in XML-style prompt tags so that user-controlled
  * text (diffs, file contents) cannot close the containing tag and break
@@ -142,6 +161,8 @@ function escapeXmlContent(content, tagName) {
  * @typedef {{
  *   sessionId: string | null,
  *   text: string,
+ *   chunkCount: number,
+ *   chunkChars: number,
  *   thoughtText: string,
  *   thoughtCount: number,
  *   thoughtChars: number,
@@ -243,70 +264,89 @@ export function getSessionRuntimeStatus(env, cwd) {
 
 // ─── ACP Operations ───────────────────────────────────────────────────────────
 
+function createNotificationSinks() {
+  return {
+    textChunks: [],
+    chunkCount: 0,
+    chunkChars: 0,
+    thoughtCount: 0,
+    thoughtChars: 0,
+    toolCalls: [],
+    fileChanges: [],
+    events: []
+  };
+}
+
+function dispatchOneNotification(notification, sinks, onStream, options = {}) {
+  const update = notification?.params?.update;
+  if (!update) return;
+  const streamThoughtText = options.streamThoughtText === true;
+
+  if (update.sessionUpdate === "agent_message_chunk" && update.content?.type === "text") {
+    const text = String(update.content.text ?? "");
+    sinks.textChunks.push(text);
+    sinks.chunkCount += 1;
+    sinks.chunkChars += text.length;
+    const ev = { type: "message_chunk", text };
+    sinks.events?.push(ev);
+    emitStreamEvent(onStream, ev);
+  } else if (update.sessionUpdate === "agent_thought_chunk" && update.content?.type === "text") {
+    const text = String(update.content.text ?? "");
+    sinks.thoughtCount += 1;
+    sinks.thoughtChars += text.length;
+    const ev = buildThoughtStreamEvent(text, streamThoughtText);
+    sinks.events?.push(ev);
+    emitStreamEvent(onStream, ev);
+  } else if (update.sessionUpdate === "tool_call") {
+    sinks.toolCalls.push({
+      name: update.toolName ?? update.name ?? "unknown",
+      arguments: update.arguments ?? update.input ?? {},
+      result: update.result ?? undefined
+    });
+    const ev = buildToolStreamEvent(update);
+    sinks.events?.push(ev);
+    emitStreamEvent(onStream, ev);
+  } else if (update.sessionUpdate === "file_change") {
+    sinks.fileChanges.push({
+      path: update.path ?? "",
+      action: update.action ?? "modify"
+    });
+    const ev = buildFileStreamEvent(update);
+    sinks.events?.push(ev);
+    emitStreamEvent(onStream, ev);
+  }
+}
+
 /**
  * Pure dispatch over a sequence of session/update notifications.
  * Exposed for tests; mirrors the real runAcpPrompt loop body.
  */
 function dispatchNotifications(notifications, onStream, options = {}) {
-  const textChunks = [];
-  let thoughtCount = 0;
-  let thoughtChars = 0;
-  const toolCalls = [];
-  const fileChanges = [];
-  const events = [];
-  const streamThoughtText = options.streamThoughtText === true;
+  const sinks = createNotificationSinks();
 
   for (const notification of notifications) {
-    const update = notification?.params?.update;
-    if (!update) continue;
-
-    if (update.sessionUpdate === "agent_message_chunk" && update.content?.type === "text") {
-      textChunks.push(update.content.text);
-      const ev = { type: "message_chunk", text: update.content.text };
-      events.push(ev);
-      emitStreamEvent(onStream, ev);
-    } else if (update.sessionUpdate === "agent_thought_chunk" && update.content?.type === "text") {
-      const text = String(update.content.text ?? "");
-      thoughtCount += 1;
-      thoughtChars += text.length;
-      const ev = buildThoughtStreamEvent(text, streamThoughtText);
-      events.push(ev);
-      emitStreamEvent(onStream, ev);
-    } else if (update.sessionUpdate === "tool_call") {
-      toolCalls.push({
-        name: update.toolName ?? update.name ?? "unknown",
-        arguments: update.arguments ?? update.input ?? {},
-        result: update.result ?? undefined
-      });
-      const ev = buildToolStreamEvent(update);
-      events.push(ev);
-      emitStreamEvent(onStream, ev);
-    } else if (update.sessionUpdate === "file_change") {
-      fileChanges.push({
-        path: update.path ?? "",
-        action: update.action ?? "modify"
-      });
-      const ev = buildFileStreamEvent(update);
-      events.push(ev);
-      emitStreamEvent(onStream, ev);
-    }
+    dispatchOneNotification(notification, sinks, onStream, options);
   }
 
   return {
-    text: textChunks.join(""),
+    text: sinks.textChunks.join(""),
+    chunkCount: sinks.chunkCount,
+    chunkChars: sinks.chunkChars,
     thoughtText: "",
-    thoughtCount,
-    thoughtChars,
-    toolCalls,
-    fileChanges,
-    events
+    thoughtCount: sinks.thoughtCount,
+    thoughtChars: sinks.thoughtChars,
+    toolCalls: sinks.toolCalls,
+    fileChanges: sinks.fileChanges,
+    events: sinks.events
   };
 }
 
 export const __testing = {
   simulateNotificationDispatch(notifications, onStream, options) {
     return dispatchNotifications(notifications, onStream, options);
-  }
+  },
+  emitThinkingWarningIfNew,
+  resetThinkingWarning
 };
 
 /**
@@ -319,41 +359,15 @@ export const __testing = {
  */
 export async function runAcpPrompt(cwd, prompt, options = {}) {
   // Collect streamed text and tool calls from session/update notifications.
-  const textChunks = [];
-  let thoughtCount = 0;
-  let thoughtChars = 0;
-  const toolCalls = [];
-  const fileChanges = [];
+  const sinks = createNotificationSinks();
   const observer = options.jobObserver && options.jobObserver.workspaceRoot && options.jobObserver.jobId
     ? options.jobObserver
     : null;
 
   const notificationHandler = (notification) => {
-    const update = notification.params?.update;
-    if (!update) return;
-
-    if (update.sessionUpdate === "agent_message_chunk" && update.content?.type === "text") {
-      textChunks.push(update.content.text);
-      emitStreamEvent(options.onStream, { type: "message_chunk", text: update.content.text });
-    } else if (update.sessionUpdate === "agent_thought_chunk" && update.content?.type === "text") {
-      const text = String(update.content.text ?? "");
-      thoughtCount += 1;
-      thoughtChars += text.length;
-      emitStreamEvent(options.onStream, buildThoughtStreamEvent(text, options.streamThoughtText === true));
-    } else if (update.sessionUpdate === "tool_call") {
-      toolCalls.push({
-        name: update.toolName ?? update.name ?? "unknown",
-        arguments: update.arguments ?? update.input ?? {},
-        result: update.result ?? undefined
-      });
-      emitStreamEvent(options.onStream, buildToolStreamEvent(update));
-    } else if (update.sessionUpdate === "file_change") {
-      fileChanges.push({
-        path: update.path ?? "",
-        action: update.action ?? "modify"
-      });
-      emitStreamEvent(options.onStream, buildFileStreamEvent(update));
-    }
+    dispatchOneNotification(notification, sinks, options.onStream, {
+      streamThoughtText: options.streamThoughtText === true
+    });
 
     recordObserverEvent(observer, buildJobEventFromAcpNotification(notification));
 
@@ -427,18 +441,8 @@ export async function runAcpPrompt(cwd, prompt, options = {}) {
       emitStreamEvent(options.onStream, { type: "phase", message: sanitizeDiagnosticMessage(`thinking:${options.thinking}`) });
       // Delivery: upstream Gemini CLI (0.38.x) does not accept a per-invocation
       // thinking override via CLI flag, env var, or session/new param; the
-      // configuration lives in settings.json at the model-alias level. Warn
-      // once per process so users understand why the flag has no observable
-      // effect, and point them at the persistent-settings path.
-      if (!globalThis.__gemini_thinking_warned) {
-        process.stderr.write(
-          "Warning: --thinking is parsed but not delivered to the running Gemini CLI. " +
-          "Configure thinkingConfig at the model-alias level in your Gemini settings.json " +
-          "for a persistent setting. See " +
-          "https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/generation-settings.md\n"
-        );
-        globalThis.__gemini_thinking_warned = true;
-      }
+      // configuration lives in settings.json at the model-alias level.
+      emitThinkingWarningIfNew();
     }
 
     // Send prompt — ACP v1 expects prompt as ContentBlock[].
@@ -448,32 +452,36 @@ export async function runAcpPrompt(cwd, prompt, options = {}) {
       prompt: [{ type: "text", text: prompt }]
     });
 
-    const text = textChunks.join("");
+    const text = sinks.textChunks.join("");
     const usage = result?._meta?.quota?.token_count ?? null;
 
     return {
       sessionId,
       text,
+      chunkCount: sinks.chunkCount,
+      chunkChars: sinks.chunkChars,
       thoughtText: "",
-      thoughtCount,
-      thoughtChars,
+      thoughtCount: sinks.thoughtCount,
+      thoughtChars: sinks.thoughtChars,
       model: result?._meta?.quota?.model_usage?.[0]?.model ?? options.model ?? null,
       usage,
-      toolCalls,
-      fileChanges,
+      toolCalls: sinks.toolCalls,
+      fileChanges: sinks.fileChanges,
       error: null
     };
   } catch (error) {
     return {
       sessionId: null,
-      text: textChunks.join(""),
+      text: sinks.textChunks.join(""),
+      chunkCount: sinks.chunkCount,
+      chunkChars: sinks.chunkChars,
       thoughtText: "",
-      thoughtCount,
-      thoughtChars,
+      thoughtCount: sinks.thoughtCount,
+      thoughtChars: sinks.thoughtChars,
       model: null,
       usage: null,
-      toolCalls,
-      fileChanges,
+      toolCalls: sinks.toolCalls,
+      fileChanges: sinks.fileChanges,
       error
     };
   } finally {

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -383,6 +383,20 @@ export async function runAcpPrompt(cwd, prompt, options = {}) {
       if (options.onStream) {
         try { options.onStream({ type: "phase", message: `thinking:${options.thinking}` }); } catch {}
       }
+      // Delivery: upstream Gemini CLI (0.38.x) does not accept a per-invocation
+      // thinking override via CLI flag, env var, or session/new param; the
+      // configuration lives in settings.json at the model-alias level. Warn
+      // once per process so users understand why the flag has no observable
+      // effect, and point them at the persistent-settings path.
+      if (!globalThis.__gemini_thinking_warned) {
+        process.stderr.write(
+          "Warning: --thinking is parsed but not delivered to the running Gemini CLI. " +
+          "Configure thinkingConfig at the model-alias level in your Gemini settings.json " +
+          "for a persistent setting. See " +
+          "https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/generation-settings.md\n"
+        );
+        globalThis.__gemini_thinking_warned = true;
+      }
     }
 
     // Send prompt — ACP v1 expects prompt as ContentBlock[].

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -83,6 +83,39 @@ function recordObserverEvent(observer, event) {
   }
 }
 
+function emitStreamEvent(onStream, event) {
+  if (!onStream) return;
+  try {
+    onStream(event);
+  } catch {
+    // Best-effort live output must not interrupt ACP handling.
+  }
+}
+
+function buildThoughtStreamEvent(text, includeText) {
+  const normalized = String(text ?? "");
+  const event = { type: "thought_chunk", chars: normalized.length };
+  if (includeText) {
+    event.text = normalized;
+  }
+  return event;
+}
+
+function buildToolStreamEvent(update) {
+  return {
+    type: "tool_call",
+    toolName: sanitizeDiagnosticMessage(update.toolName ?? update.name ?? "unknown") || "unknown"
+  };
+}
+
+function buildFileStreamEvent(update) {
+  return {
+    type: "file_change",
+    path: sanitizeDiagnosticMessage(update.path ?? ""),
+    action: sanitizeDiagnosticMessage(update.action ?? "modify") || "modify"
+  };
+}
+
 /**
  * Escape content embedded in XML-style prompt tags so that user-controlled
  * text (diffs, file contents) cannot close the containing tag and break
@@ -110,6 +143,8 @@ function escapeXmlContent(content, tagName) {
  *   sessionId: string | null,
  *   text: string,
  *   thoughtText: string,
+ *   thoughtCount: number,
+ *   thoughtChars: number,
  *   model: string | null,
  *   usage: { promptTokens: number, completionTokens: number, totalTokens: number } | null,
  *   toolCalls: Array<{ name: string, arguments: Record<string, unknown>, result?: string }>,
@@ -212,12 +247,14 @@ export function getSessionRuntimeStatus(env, cwd) {
  * Pure dispatch over a sequence of session/update notifications.
  * Exposed for tests; mirrors the real runAcpPrompt loop body.
  */
-function dispatchNotifications(notifications, onStream) {
+function dispatchNotifications(notifications, onStream, options = {}) {
   const textChunks = [];
-  const thoughtChunks = [];
+  let thoughtCount = 0;
+  let thoughtChars = 0;
   const toolCalls = [];
   const fileChanges = [];
   const events = [];
+  const streamThoughtText = options.streamThoughtText === true;
 
   for (const notification of notifications) {
     const update = notification?.params?.update;
@@ -227,35 +264,39 @@ function dispatchNotifications(notifications, onStream) {
       textChunks.push(update.content.text);
       const ev = { type: "message_chunk", text: update.content.text };
       events.push(ev);
-      if (onStream) { try { onStream(ev); } catch { /* best-effort */ } }
+      emitStreamEvent(onStream, ev);
     } else if (update.sessionUpdate === "agent_thought_chunk" && update.content?.type === "text") {
-      thoughtChunks.push(update.content.text);
-      const ev = { type: "thought_chunk", text: update.content.text };
+      const text = String(update.content.text ?? "");
+      thoughtCount += 1;
+      thoughtChars += text.length;
+      const ev = buildThoughtStreamEvent(text, streamThoughtText);
       events.push(ev);
-      if (onStream) { try { onStream(ev); } catch { /* best-effort */ } }
+      emitStreamEvent(onStream, ev);
     } else if (update.sessionUpdate === "tool_call") {
       toolCalls.push({
         name: update.toolName ?? update.name ?? "unknown",
         arguments: update.arguments ?? update.input ?? {},
         result: update.result ?? undefined
       });
-      const ev = { type: "tool_call", toolName: update.toolName ?? update.name ?? "unknown" };
+      const ev = buildToolStreamEvent(update);
       events.push(ev);
-      if (onStream) { try { onStream(ev); } catch { /* best-effort */ } }
+      emitStreamEvent(onStream, ev);
     } else if (update.sessionUpdate === "file_change") {
       fileChanges.push({
         path: update.path ?? "",
         action: update.action ?? "modify"
       });
-      const ev = { type: "file_change", path: update.path ?? "", action: update.action ?? "modify" };
+      const ev = buildFileStreamEvent(update);
       events.push(ev);
-      if (onStream) { try { onStream(ev); } catch { /* best-effort */ } }
+      emitStreamEvent(onStream, ev);
     }
   }
 
   return {
     text: textChunks.join(""),
-    thoughtText: thoughtChunks.join(""),
+    thoughtText: "",
+    thoughtCount,
+    thoughtChars,
     toolCalls,
     fileChanges,
     events
@@ -263,8 +304,8 @@ function dispatchNotifications(notifications, onStream) {
 }
 
 export const __testing = {
-  simulateNotificationDispatch(notifications, onStream) {
-    return dispatchNotifications(notifications, onStream);
+  simulateNotificationDispatch(notifications, onStream, options) {
+    return dispatchNotifications(notifications, onStream, options);
   }
 };
 
@@ -273,13 +314,14 @@ export const __testing = {
  *
  * @param {string} cwd
  * @param {string} prompt
- * @param {{ model?: string, thinkingBudget?: number, thinking?: "off"|"low"|"medium"|"high", approvalMode?: string, sessionId?: string, env?: NodeJS.ProcessEnv, onNotification?: (n: any) => void, onStream?: (event: any) => void }} [options]
+ * @param {{ model?: string, thinkingBudget?: number, thinking?: "off"|"low"|"medium"|"high", approvalMode?: string, sessionId?: string, env?: NodeJS.ProcessEnv, onNotification?: (n: any) => void, onStream?: (event: any) => void, streamThoughtText?: boolean }} [options]
  * @returns {Promise<TurnResult>}
  */
 export async function runAcpPrompt(cwd, prompt, options = {}) {
   // Collect streamed text and tool calls from session/update notifications.
   const textChunks = [];
-  const thoughtChunks = [];
+  let thoughtCount = 0;
+  let thoughtChars = 0;
   const toolCalls = [];
   const fileChanges = [];
   const observer = options.jobObserver && options.jobObserver.workspaceRoot && options.jobObserver.jobId
@@ -292,23 +334,25 @@ export async function runAcpPrompt(cwd, prompt, options = {}) {
 
     if (update.sessionUpdate === "agent_message_chunk" && update.content?.type === "text") {
       textChunks.push(update.content.text);
-      if (options.onStream) { try { options.onStream({ type: "message_chunk", text: update.content.text }); } catch {} }
+      emitStreamEvent(options.onStream, { type: "message_chunk", text: update.content.text });
     } else if (update.sessionUpdate === "agent_thought_chunk" && update.content?.type === "text") {
-      thoughtChunks.push(update.content.text);
-      if (options.onStream) { try { options.onStream({ type: "thought_chunk", text: update.content.text }); } catch {} }
+      const text = String(update.content.text ?? "");
+      thoughtCount += 1;
+      thoughtChars += text.length;
+      emitStreamEvent(options.onStream, buildThoughtStreamEvent(text, options.streamThoughtText === true));
     } else if (update.sessionUpdate === "tool_call") {
       toolCalls.push({
         name: update.toolName ?? update.name ?? "unknown",
         arguments: update.arguments ?? update.input ?? {},
         result: update.result ?? undefined
       });
-      if (options.onStream) { try { options.onStream({ type: "tool_call", toolName: update.toolName ?? update.name ?? "unknown" }); } catch {} }
+      emitStreamEvent(options.onStream, buildToolStreamEvent(update));
     } else if (update.sessionUpdate === "file_change") {
       fileChanges.push({
         path: update.path ?? "",
         action: update.action ?? "modify"
       });
-      if (options.onStream) { try { options.onStream({ type: "file_change", path: update.path ?? "", action: update.action ?? "modify" }); } catch {} }
+      emitStreamEvent(options.onStream, buildFileStreamEvent(update));
     }
 
     recordObserverEvent(observer, buildJobEventFromAcpNotification(notification));
@@ -342,7 +386,7 @@ export async function runAcpPrompt(cwd, prompt, options = {}) {
     if (sessionId) {
       await client.request("session/load", { sessionId, cwd, mcpServers: [] });
       recordObserverEvent(observer, { type: "phase", message: "session_loaded" });
-      if (options.onStream) { try { options.onStream({ type: "phase", message: "session_loaded" }); } catch {} }
+      emitStreamEvent(options.onStream, { type: "phase", message: "session_loaded" });
     } else {
       const session = await client.request("session/new", {
         cwd,
@@ -350,7 +394,7 @@ export async function runAcpPrompt(cwd, prompt, options = {}) {
       });
       sessionId = session?.sessionId ?? null;
       recordObserverEvent(observer, { type: "phase", message: "session_created" });
-      if (options.onStream) { try { options.onStream({ type: "phase", message: "session_created" }); } catch {} }
+      emitStreamEvent(options.onStream, { type: "phase", message: "session_created" });
     }
 
     // Set approval mode (defaults to autoEdit if not specified).
@@ -380,9 +424,7 @@ export async function runAcpPrompt(cwd, prompt, options = {}) {
         process.stderr.write(`Thinking: ${note}\n`);
       }
       recordObserverEvent(observer, { type: "phase", message: `thinking:${options.thinking}` });
-      if (options.onStream) {
-        try { options.onStream({ type: "phase", message: `thinking:${options.thinking}` }); } catch {}
-      }
+      emitStreamEvent(options.onStream, { type: "phase", message: sanitizeDiagnosticMessage(`thinking:${options.thinking}`) });
       // Delivery: upstream Gemini CLI (0.38.x) does not accept a per-invocation
       // thinking override via CLI flag, env var, or session/new param; the
       // configuration lives in settings.json at the model-alias level. Warn
@@ -412,7 +454,9 @@ export async function runAcpPrompt(cwd, prompt, options = {}) {
     return {
       sessionId,
       text,
-      thoughtText: thoughtChunks.join(""),
+      thoughtText: "",
+      thoughtCount,
+      thoughtChars,
       model: result?._meta?.quota?.model_usage?.[0]?.model ?? options.model ?? null,
       usage,
       toolCalls,
@@ -423,7 +467,9 @@ export async function runAcpPrompt(cwd, prompt, options = {}) {
     return {
       sessionId: null,
       text: textChunks.join(""),
-      thoughtText: thoughtChunks.join(""),
+      thoughtText: "",
+      thoughtCount,
+      thoughtChars,
       model: null,
       usage: null,
       toolCalls,
@@ -439,7 +485,7 @@ export async function runAcpPrompt(cwd, prompt, options = {}) {
  * Run a code review via ACP. Collects git context and sends a review prompt.
  *
  * @param {string} cwd
- * @param {{ scope?: string, base?: string, model?: string, thinking?: "off"|"low"|"medium"|"high", env?: NodeJS.ProcessEnv, onNotification?: (n: any) => void, onStream?: (event: any) => void }} [options]
+ * @param {{ scope?: string, base?: string, model?: string, thinking?: "off"|"low"|"medium"|"high", env?: NodeJS.ProcessEnv, onNotification?: (n: any) => void, onStream?: (event: any) => void, streamThoughtText?: boolean }} [options]
  * @returns {Promise<{ text: string, sessionId: string | null, scope: string, summary: string, error: unknown }>}
  */
 export async function runAcpReview(cwd, options = {}) {
@@ -464,6 +510,7 @@ export async function runAcpReview(cwd, options = {}) {
     model: options.model,
     thinking: options.thinking,
     onStream: options.onStream,
+    streamThoughtText: options.streamThoughtText,
     approvalMode: "plan", // Read-only for reviews.
     env: options.env,
     onNotification: options.onNotification,
@@ -484,7 +531,7 @@ export async function runAcpReview(cwd, options = {}) {
  * Run an adversarial review via ACP with a structured output prompt.
  *
  * @param {string} cwd
- * @param {{ scope?: string, base?: string, model?: string, thinking?: "off"|"low"|"medium"|"high", focus?: string, schemaPath?: string, env?: NodeJS.ProcessEnv, onNotification?: (n: any) => void, onStream?: (event: any) => void }} [options]
+ * @param {{ scope?: string, base?: string, model?: string, thinking?: "off"|"low"|"medium"|"high", focus?: string, schemaPath?: string, env?: NodeJS.ProcessEnv, onNotification?: (n: any) => void, onStream?: (event: any) => void, streamThoughtText?: boolean }} [options]
  * @returns {Promise<{ text: string, parsed: any, sessionId: string | null, scope: string, error: unknown }>}
  */
 export async function runAcpAdversarialReview(cwd, options = {}) {
@@ -532,6 +579,7 @@ export async function runAcpAdversarialReview(cwd, options = {}) {
     model: options.model,
     thinking: options.thinking,
     onStream: options.onStream,
+    streamThoughtText: options.streamThoughtText,
     approvalMode: "plan", // Read-only for reviews.
     env: options.env,
     onNotification: options.onNotification,

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -32,6 +32,10 @@ export function buildJobEventFromAcpNotification(notification) {
     // streaming") without leaking the model's prose through the event log.
     return { type: "model_text_chunk", chars: String(text).length };
   }
+  if (kind === "agent_thought_chunk") {
+    const text = update.content?.text ?? "";
+    return { type: "model_thought_chunk", chars: String(text).length };
+  }
   if (kind === "tool_call") {
     return {
       type: "tool_call",

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -14,6 +14,7 @@ import { binaryAvailable, runCommand } from "./process.mjs";
 import { collectReviewContext } from "./git.mjs";
 import { loadPrompt } from "./prompts.mjs";
 import { recordJobEvent } from "./job-observability.mjs";
+import { resolveThinkingConfig } from "./thinking.mjs";
 
 /**
  * Convert an ACP session/update notification into a job-observability event.
@@ -108,6 +109,7 @@ function escapeXmlContent(content, tagName) {
  * @typedef {{
  *   sessionId: string | null,
  *   text: string,
+ *   thoughtText: string,
  *   model: string | null,
  *   usage: { promptTokens: number, completionTokens: number, totalTokens: number } | null,
  *   toolCalls: Array<{ name: string, arguments: Record<string, unknown>, result?: string }>,
@@ -207,16 +209,77 @@ export function getSessionRuntimeStatus(env, cwd) {
 // ─── ACP Operations ───────────────────────────────────────────────────────────
 
 /**
+ * Pure dispatch over a sequence of session/update notifications.
+ * Exposed for tests; mirrors the real runAcpPrompt loop body.
+ */
+function dispatchNotifications(notifications, onStream) {
+  const textChunks = [];
+  const thoughtChunks = [];
+  const toolCalls = [];
+  const fileChanges = [];
+  const events = [];
+
+  for (const notification of notifications) {
+    const update = notification?.params?.update;
+    if (!update) continue;
+
+    if (update.sessionUpdate === "agent_message_chunk" && update.content?.type === "text") {
+      textChunks.push(update.content.text);
+      const ev = { type: "message_chunk", text: update.content.text };
+      events.push(ev);
+      if (onStream) { try { onStream(ev); } catch { /* best-effort */ } }
+    } else if (update.sessionUpdate === "agent_thought_chunk" && update.content?.type === "text") {
+      thoughtChunks.push(update.content.text);
+      const ev = { type: "thought_chunk", text: update.content.text };
+      events.push(ev);
+      if (onStream) { try { onStream(ev); } catch { /* best-effort */ } }
+    } else if (update.sessionUpdate === "tool_call") {
+      toolCalls.push({
+        name: update.toolName ?? update.name ?? "unknown",
+        arguments: update.arguments ?? update.input ?? {},
+        result: update.result ?? undefined
+      });
+      const ev = { type: "tool_call", toolName: update.toolName ?? update.name ?? "unknown" };
+      events.push(ev);
+      if (onStream) { try { onStream(ev); } catch { /* best-effort */ } }
+    } else if (update.sessionUpdate === "file_change") {
+      fileChanges.push({
+        path: update.path ?? "",
+        action: update.action ?? "modify"
+      });
+      const ev = { type: "file_change", path: update.path ?? "", action: update.action ?? "modify" };
+      events.push(ev);
+      if (onStream) { try { onStream(ev); } catch { /* best-effort */ } }
+    }
+  }
+
+  return {
+    text: textChunks.join(""),
+    thoughtText: thoughtChunks.join(""),
+    toolCalls,
+    fileChanges,
+    events
+  };
+}
+
+export const __testing = {
+  simulateNotificationDispatch(notifications, onStream) {
+    return dispatchNotifications(notifications, onStream);
+  }
+};
+
+/**
  * Run a prompt through Gemini ACP and capture the result.
  *
  * @param {string} cwd
  * @param {string} prompt
- * @param {{ model?: string, thinkingBudget?: number, approvalMode?: string, sessionId?: string, env?: NodeJS.ProcessEnv, onNotification?: (n: any) => void }} [options]
+ * @param {{ model?: string, thinkingBudget?: number, thinking?: "off"|"low"|"medium"|"high", approvalMode?: string, sessionId?: string, env?: NodeJS.ProcessEnv, onNotification?: (n: any) => void, onStream?: (event: any) => void }} [options]
  * @returns {Promise<TurnResult>}
  */
 export async function runAcpPrompt(cwd, prompt, options = {}) {
   // Collect streamed text and tool calls from session/update notifications.
   const textChunks = [];
+  const thoughtChunks = [];
   const toolCalls = [];
   const fileChanges = [];
   const observer = options.jobObserver && options.jobObserver.workspaceRoot && options.jobObserver.jobId
@@ -224,29 +287,28 @@ export async function runAcpPrompt(cwd, prompt, options = {}) {
     : null;
 
   const notificationHandler = (notification) => {
-    // NOTE: broker/diagnostic notifications are single-dispatched by
-    // AcpClientBase.handleLine via `onDiagnostic` only in broker-transport
-    // mode, and ignored as trusted in direct mode. No broker-diagnostic
-    // branch is needed here — it would double-count in broker mode and
-    // trust a forged payload in direct mode.
     const update = notification.params?.update;
-    if (!update) {
-      return;
-    }
+    if (!update) return;
 
     if (update.sessionUpdate === "agent_message_chunk" && update.content?.type === "text") {
       textChunks.push(update.content.text);
+      if (options.onStream) { try { options.onStream({ type: "message_chunk", text: update.content.text }); } catch {} }
+    } else if (update.sessionUpdate === "agent_thought_chunk" && update.content?.type === "text") {
+      thoughtChunks.push(update.content.text);
+      if (options.onStream) { try { options.onStream({ type: "thought_chunk", text: update.content.text }); } catch {} }
     } else if (update.sessionUpdate === "tool_call") {
       toolCalls.push({
         name: update.toolName ?? update.name ?? "unknown",
         arguments: update.arguments ?? update.input ?? {},
         result: update.result ?? undefined
       });
+      if (options.onStream) { try { options.onStream({ type: "tool_call", toolName: update.toolName ?? update.name ?? "unknown" }); } catch {} }
     } else if (update.sessionUpdate === "file_change") {
       fileChanges.push({
         path: update.path ?? "",
         action: update.action ?? "modify"
       });
+      if (options.onStream) { try { options.onStream({ type: "file_change", path: update.path ?? "", action: update.action ?? "modify" }); } catch {} }
     }
 
     recordObserverEvent(observer, buildJobEventFromAcpNotification(notification));
@@ -280,6 +342,7 @@ export async function runAcpPrompt(cwd, prompt, options = {}) {
     if (sessionId) {
       await client.request("session/load", { sessionId, cwd, mcpServers: [] });
       recordObserverEvent(observer, { type: "phase", message: "session_loaded" });
+      if (options.onStream) { try { options.onStream({ type: "phase", message: "session_loaded" }); } catch {} }
     } else {
       const session = await client.request("session/new", {
         cwd,
@@ -287,6 +350,7 @@ export async function runAcpPrompt(cwd, prompt, options = {}) {
       });
       sessionId = session?.sessionId ?? null;
       recordObserverEvent(observer, { type: "phase", message: "session_created" });
+      if (options.onStream) { try { options.onStream({ type: "phase", message: "session_created" }); } catch {} }
     }
 
     // Set approval mode (defaults to autoEdit if not specified).
@@ -309,6 +373,18 @@ export async function runAcpPrompt(cwd, prompt, options = {}) {
       }
     }
 
+    let resolvedThinking = null;
+    if (options.thinking !== undefined) {
+      resolvedThinking = resolveThinkingConfig(options.thinking, options.model ?? null);
+      for (const note of resolvedThinking.notes) {
+        process.stderr.write(`Thinking: ${note}\n`);
+      }
+      recordObserverEvent(observer, { type: "phase", message: `thinking:${options.thinking}` });
+      if (options.onStream) {
+        try { options.onStream({ type: "phase", message: `thinking:${options.thinking}` }); } catch {}
+      }
+    }
+
     // Send prompt — ACP v1 expects prompt as ContentBlock[].
     // Text is streamed via session/update notifications; the response only has metadata.
     const result = await client.request("session/prompt", {
@@ -322,6 +398,7 @@ export async function runAcpPrompt(cwd, prompt, options = {}) {
     return {
       sessionId,
       text,
+      thoughtText: thoughtChunks.join(""),
       model: result?._meta?.quota?.model_usage?.[0]?.model ?? options.model ?? null,
       usage,
       toolCalls,
@@ -332,6 +409,7 @@ export async function runAcpPrompt(cwd, prompt, options = {}) {
     return {
       sessionId: null,
       text: textChunks.join(""),
+      thoughtText: thoughtChunks.join(""),
       model: null,
       usage: null,
       toolCalls,
@@ -347,7 +425,7 @@ export async function runAcpPrompt(cwd, prompt, options = {}) {
  * Run a code review via ACP. Collects git context and sends a review prompt.
  *
  * @param {string} cwd
- * @param {{ scope?: string, base?: string, model?: string, env?: NodeJS.ProcessEnv, onNotification?: (n: any) => void }} [options]
+ * @param {{ scope?: string, base?: string, model?: string, thinking?: "off"|"low"|"medium"|"high", env?: NodeJS.ProcessEnv, onNotification?: (n: any) => void, onStream?: (event: any) => void }} [options]
  * @returns {Promise<{ text: string, sessionId: string | null, scope: string, summary: string, error: unknown }>}
  */
 export async function runAcpReview(cwd, options = {}) {
@@ -370,6 +448,8 @@ export async function runAcpReview(cwd, options = {}) {
 
   const result = await runAcpPrompt(cwd, reviewPrompt, {
     model: options.model,
+    thinking: options.thinking,
+    onStream: options.onStream,
     approvalMode: "plan", // Read-only for reviews.
     env: options.env,
     onNotification: options.onNotification,
@@ -390,7 +470,7 @@ export async function runAcpReview(cwd, options = {}) {
  * Run an adversarial review via ACP with a structured output prompt.
  *
  * @param {string} cwd
- * @param {{ scope?: string, base?: string, model?: string, focus?: string, schemaPath?: string, env?: NodeJS.ProcessEnv, onNotification?: (n: any) => void }} [options]
+ * @param {{ scope?: string, base?: string, model?: string, thinking?: "off"|"low"|"medium"|"high", focus?: string, schemaPath?: string, env?: NodeJS.ProcessEnv, onNotification?: (n: any) => void, onStream?: (event: any) => void }} [options]
  * @returns {Promise<{ text: string, parsed: any, sessionId: string | null, scope: string, error: unknown }>}
  */
 export async function runAcpAdversarialReview(cwd, options = {}) {
@@ -436,6 +516,8 @@ export async function runAcpAdversarialReview(cwd, options = {}) {
 
   const result = await runAcpPrompt(cwd, fullPrompt, {
     model: options.model,
+    thinking: options.thinking,
+    onStream: options.onStream,
     approvalMode: "plan", // Read-only for reviews.
     env: options.env,
     onNotification: options.onNotification,

--- a/plugins/gemini/scripts/lib/job-observability.mjs
+++ b/plugins/gemini/scripts/lib/job-observability.mjs
@@ -7,6 +7,7 @@ export const MAX_JOB_EVENTS = 50;
 
 const PROGRESS_EVENT_TYPES = new Set([
   "model_text_chunk",
+  "model_thought_chunk",
   "tool_call",
   "file_change",
   "phase",
@@ -154,7 +155,10 @@ export function normalizeAndAppendEvent(job, event) {
     patch.recommendedAction = null;
   }
 
-  if (normalizedEvent.type === "model_text_chunk" && !preserveTerminalHealth) {
+  if (
+    (normalizedEvent.type === "model_text_chunk" || normalizedEvent.type === "model_thought_chunk") &&
+    !preserveTerminalHealth
+  ) {
     patch.lastModelOutputAt = persistedTimestamp;
   }
 

--- a/plugins/gemini/scripts/lib/render.mjs
+++ b/plugins/gemini/scripts/lib/render.mjs
@@ -109,14 +109,54 @@ export function renderStatusSnapshot(snapshot) {
   return `${lines.join("\n").trimEnd()}\n`;
 }
 
+const TAIL_N = 5;
+
+function formatEventLineBrief(event) {
+  switch (event.type) {
+    case "model_text_chunk":
+    case "model_thought_chunk":
+      return `[${event.type}] ${event.chars ?? 0} chars`;
+    case "tool_call":
+      return `[tool_call] ${event.toolName ?? "unknown"}`;
+    case "file_change":
+      return `[file_change] ${event.action ?? "modify"} ${event.path ?? ""}`;
+    case "phase":
+      return `[phase] ${event.message ?? ""}`;
+    case "diagnostic":
+      return `[diagnostic] ${event.source ?? "unknown"}: ${event.message ?? ""}`;
+    default:
+      return `[${event.type ?? "event"}]`;
+  }
+}
+
+function formatAgo(nowMs, timestamp) {
+  const tsMs = Date.parse(timestamp ?? "");
+  if (Number.isNaN(tsMs)) return "";
+  const delta = Math.max(0, nowMs - tsMs);
+  if (delta < 1000) return `${delta}ms ago`;
+  return `${(delta / 1000).toFixed(1)}s ago`;
+}
+
+function rollupCounters(events) {
+  const c = { chunks: 0, thoughts: 0, tools: 0, files: 0 };
+  for (const e of events) {
+    if (e.type === "model_text_chunk") c.chunks += 1;
+    else if (e.type === "model_thought_chunk") c.thoughts += 1;
+    else if (e.type === "tool_call") c.tools += 1;
+    else if (e.type === "file_change") c.files += 1;
+  }
+  return c;
+}
+
 /**
  * Render a single job's detailed status.
  *
- * @param {{ job: any }} snapshot
+ * @param {{ job: any } | any} snapshotOrJob - Either a { job } wrapper (legacy) or a bare job object.
+ * @param {{ now?: number }} [options]
  * @returns {string}
  */
-export function renderSingleJobStatus(snapshot) {
-  const job = snapshot.job;
+export function renderSingleJobStatus(snapshotOrJob, options = {}) {
+  const job = snapshotOrJob && snapshotOrJob.job != null ? snapshotOrJob.job : snapshotOrJob;
   const lines = [];
   lines.push(`# Gemini Job: ${job.id}`);
   lines.push("");
@@ -172,13 +212,22 @@ export function renderSingleJobStatus(snapshot) {
     }
   }
 
-  if (job.events && job.events.length > 0) {
+  if (Array.isArray(job.events) && job.events.length > 0) {
+    const nowMs = options?.now ?? Date.now();
+    const allEvents = job.events;
+    const tail = allEvents.slice(-TAIL_N);
+    const last = allEvents[allEvents.length - 1];
+    const counters = rollupCounters(allEvents);
+
     lines.push("");
     lines.push("## Recent Events");
     lines.push("");
-    for (const event of job.events) {
-      lines.push(`- ${formatEventLine(event)}`);
+    lines.push(`  last event: ${formatEventLineBrief(last)} - ${formatAgo(nowMs, last.timestamp)}`);
+    lines.push("  recent:");
+    for (const event of tail) {
+      lines.push(`    ${formatEventLineBrief(event)}  ${formatAgo(nowMs, event.timestamp)}`);
     }
+    lines.push(`  totals: chunks=${counters.chunks}  thoughts=${counters.thoughts}  tools=${counters.tools}  files=${counters.files}`);
   }
 
   return `${lines.join("\n").trimEnd()}\n`;

--- a/plugins/gemini/scripts/lib/render.mjs
+++ b/plugins/gemini/scripts/lib/render.mjs
@@ -122,8 +122,14 @@ function formatEventLineBrief(event) {
       return `[file_change] ${event.action ?? "modify"} ${event.path ?? ""}`;
     case "phase":
       return `[phase] ${event.message ?? ""}`;
+    case "phase_changed":
+      return `[phase_changed] ${event.phase ?? event.message ?? ""}`;
     case "diagnostic":
-      return `[diagnostic] ${event.source ?? "unknown"}: ${event.message ?? ""}`;
+    case "error":
+    case "stderr":
+      return event.source
+        ? `[${event.type}] ${event.source}: ${event.message ?? ""}`
+        : `[${event.type}] ${event.message ?? ""}`;
     default:
       return `[${event.type ?? "event"}]`;
   }
@@ -156,7 +162,12 @@ function rollupCounters(events) {
  * @returns {string}
  */
 export function renderSingleJobStatus(snapshotOrJob, options = {}) {
-  const job = snapshotOrJob && snapshotOrJob.job != null ? snapshotOrJob.job : snapshotOrJob;
+  const isSnapshotWrapper =
+    snapshotOrJob &&
+    typeof snapshotOrJob === "object" &&
+    Object.prototype.hasOwnProperty.call(snapshotOrJob, "workspaceRoot") &&
+    Object.prototype.hasOwnProperty.call(snapshotOrJob, "job");
+  const job = isSnapshotWrapper ? snapshotOrJob.job : snapshotOrJob;
   const lines = [];
   lines.push(`# Gemini Job: ${job.id}`);
   lines.push("");

--- a/plugins/gemini/scripts/lib/stream-output.mjs
+++ b/plugins/gemini/scripts/lib/stream-output.mjs
@@ -9,6 +9,8 @@
  * allows passthrough mode (user opted in explicitly).
  */
 
+import { sanitizeDiagnosticMessage } from "./acp-diagnostics.mjs";
+
 export const STREAM_MODES = ["markers", "passthrough"];
 
 const MODE_SET = new Set(STREAM_MODES);
@@ -62,6 +64,10 @@ function formatElapsed(ms) {
   return `${(ms / 1000).toFixed(1)}s`;
 }
 
+function markerField(value, fallback = "") {
+  return sanitizeDiagnosticMessage(value) || fallback;
+}
+
 /**
  * @param {{ mode: string, json: boolean, writer: (s: string) => any }} opts
  * @returns {(event: StreamEvent) => void}
@@ -92,7 +98,7 @@ export function createStreamHandler({ mode, json, writer }) {
     // markers mode
     switch (event.type) {
       case "phase": {
-        const raw = event.message ?? "";
+        const raw = markerField(event.message);
         const isSession = raw.startsWith("session_");
         const label = isSession ? "session" : "phase";
         const msg = isSession ? raw.replace(/^session_/, "") : raw;
@@ -100,7 +106,7 @@ export function createStreamHandler({ mode, json, writer }) {
         return;
       }
       case "tool_call":
-        safeWrite(writer, `[tool] ${event.toolName ?? "unknown"}\n`);
+        safeWrite(writer, `[tool] ${markerField(event.toolName, "unknown")}\n`);
         return;
       case "message_chunk":
         safeWrite(writer, ".");
@@ -109,7 +115,7 @@ export function createStreamHandler({ mode, json, writer }) {
         safeWrite(writer, "[thinking]\n");
         return;
       case "file_change":
-        safeWrite(writer, `[file] ${event.action ?? "modify"} ${event.path ?? ""}\n`);
+        safeWrite(writer, `[file] ${markerField(event.action, "modify")} ${markerField(event.path)}\n`);
         return;
       case "done": {
         const s = event.stats ?? {};

--- a/plugins/gemini/scripts/lib/stream-output.mjs
+++ b/plugins/gemini/scripts/lib/stream-output.mjs
@@ -1,0 +1,130 @@
+/**
+ * Stderr stream handler factory for foreground ACP runs.
+ *
+ * Two modes:
+ *  - "markers": compact one-line-per-event markers
+ *  - "passthrough": raw chunk text, with "thought: " prefix on thought chunks
+ *
+ * json=true suppresses markers mode (keeps stdout JSON clean) but still
+ * allows passthrough mode (user opted in explicitly).
+ */
+
+export const STREAM_MODES = ["markers", "passthrough"];
+
+const MODE_SET = new Set(STREAM_MODES);
+
+/**
+ * @typedef {Object} StreamEventPhase
+ * @property {"phase"} type
+ * @property {string} message
+ *
+ * @typedef {Object} StreamEventTool
+ * @property {"tool_call"} type
+ * @property {string} toolName
+ *
+ * @typedef {Object} StreamEventMessage
+ * @property {"message_chunk"} type
+ * @property {string} text
+ *
+ * @typedef {Object} StreamEventThought
+ * @property {"thought_chunk"} type
+ * @property {string} text
+ *
+ * @typedef {Object} StreamEventFile
+ * @property {"file_change"} type
+ * @property {string} path
+ * @property {string} action
+ *
+ * @typedef {Object} StreamEventDone
+ * @property {"done"} type
+ * @property {{ tools: number, files: number, chunks: number, thoughts: number, elapsedMs: number }} stats
+ *
+ * @typedef {StreamEventPhase|StreamEventTool|StreamEventMessage|StreamEventThought|StreamEventFile|StreamEventDone} StreamEvent
+ */
+
+function safeWrite(writer, data) {
+  try {
+    writer(data);
+  } catch (error) {
+    if (error && (error.code === "EPIPE" || error.code === "ERR_STREAM_DESTROYED")) {
+      return;
+    }
+    throw error;
+  }
+}
+
+function plural(n, word) {
+  return `${n} ${word}${n === 1 ? "" : "s"}`;
+}
+
+function formatElapsed(ms) {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+/**
+ * @param {{ mode: string, json: boolean, writer: (s: string) => any }} opts
+ * @returns {(event: StreamEvent) => void}
+ */
+export function createStreamHandler({ mode, json, writer }) {
+  if (!MODE_SET.has(mode)) {
+    throw new Error(`Invalid stream mode: ${mode}. Expected one of ${STREAM_MODES.join(", ")}.`);
+  }
+
+  const suppressMarkers = mode === "markers" && json === true;
+
+  return function handle(event) {
+    if (!event || typeof event !== "object") return;
+    if (suppressMarkers) return;
+
+    if (mode === "passthrough") {
+      if (event.type === "message_chunk" && typeof event.text === "string") {
+        safeWrite(writer, event.text);
+        return;
+      }
+      if (event.type === "thought_chunk" && typeof event.text === "string") {
+        safeWrite(writer, `thought: ${event.text}\n`);
+        return;
+      }
+      return;
+    }
+
+    // markers mode
+    switch (event.type) {
+      case "phase": {
+        const raw = event.message ?? "";
+        const isSession = raw.startsWith("session_");
+        const label = isSession ? "session" : "phase";
+        const msg = isSession ? raw.replace(/^session_/, "") : raw;
+        safeWrite(writer, `[${label}] ${msg}\n`);
+        return;
+      }
+      case "tool_call":
+        safeWrite(writer, `[tool] ${event.toolName ?? "unknown"}\n`);
+        return;
+      case "message_chunk":
+        safeWrite(writer, ".");
+        return;
+      case "thought_chunk":
+        safeWrite(writer, "[thinking]\n");
+        return;
+      case "file_change":
+        safeWrite(writer, `[file] ${event.action ?? "modify"} ${event.path ?? ""}\n`);
+        return;
+      case "done": {
+        const s = event.stats ?? {};
+        const parts = [
+          formatElapsed(s.elapsedMs ?? 0),
+          plural(s.tools ?? 0, "tool"),
+          plural(s.files ?? 0, "file"),
+          plural(s.chunks ?? 0, "chunk"),
+          plural(s.thoughts ?? 0, "thought")
+        ];
+        safeWrite(writer, `[done] ${parts.join(" | ")}\n`);
+        return;
+      }
+      default:
+        return;
+    }
+  };
+}

--- a/plugins/gemini/scripts/lib/thinking.mjs
+++ b/plugins/gemini/scripts/lib/thinking.mjs
@@ -56,14 +56,16 @@ export function resolveThinkingConfig(level, modelId) {
       return { thinkingLevel: "low", thinkingBudget: undefined, notes };
     }
     if (level === "low") return { thinkingLevel: "low", thinkingBudget: undefined, notes };
+    if (level === "medium") {
+      notes.push("gemini-3 medium uses model default dynamic thinking");
+      return { thinkingLevel: undefined, thinkingBudget: undefined, notes };
+    }
     if (level === "high") return { thinkingLevel: "high", thinkingBudget: undefined, notes };
-    // medium: no explicit level; Gemini 3 uses its own dynamic default.
-    return { thinkingLevel: undefined, thinkingBudget: undefined, notes };
   }
 
   if (family === "gemini-2.5-pro") {
     if (level === "off") {
-      notes.push("clamped off→low: Gemini 2.5 Pro minimum thinkingBudget is 128");
+      notes.push("clamped off→low: Gemini 2.5 Pro does not support disabling thinking; using thinkingBudget 2048 (API minimum is 128)");
       return { thinkingLevel: undefined, thinkingBudget: 2048, notes };
     }
     if (level === "low") return { thinkingLevel: undefined, thinkingBudget: 2048, notes };
@@ -78,5 +80,5 @@ export function resolveThinkingConfig(level, modelId) {
     if (level === "high") return { thinkingLevel: undefined, thinkingBudget: 24576, notes };
   }
 
-  return { thinkingLevel: undefined, thinkingBudget: undefined, notes };
+  throw new Error(`unreachable: unhandled thinking level/family combination (${level}, ${family})`);
 }

--- a/plugins/gemini/scripts/lib/thinking.mjs
+++ b/plugins/gemini/scripts/lib/thinking.mjs
@@ -1,0 +1,82 @@
+/**
+ * Thinking t-shirt sizing resolver.
+ *
+ * Maps a categorical level (off/low/medium/high) to the concrete
+ * thinking configuration the current Gemini CLI expects, given the
+ * target model family.
+ *
+ * Gemini 3 models use `thinkingLevel` ("low" | "high").
+ * Gemini 2.5 models use `thinkingBudget` (numeric; -1 = dynamic, 0 = off).
+ */
+
+export const THINKING_LEVELS = ["off", "low", "medium", "high"];
+
+const LEVEL_SET = new Set(THINKING_LEVELS);
+
+/**
+ * @typedef {Object} ThinkingConfig
+ * @property {"low"|"high"|undefined} thinkingLevel
+ * @property {number|undefined} thinkingBudget
+ * @property {string[]} notes
+ */
+
+function detectFamily(modelId) {
+  if (!modelId || typeof modelId !== "string") return "unknown";
+  if (/^gemini-3(\.|-|$)/.test(modelId) || /^auto-gemini-3/.test(modelId)) return "gemini-3";
+  if (/^gemini-2\.5-flash-lite/.test(modelId)) return "gemini-2.5-flash-lite";
+  if (/^gemini-2\.5-flash/.test(modelId)) return "gemini-2.5-flash";
+  if (/^gemini-2\.5-pro/.test(modelId) || /^auto-gemini-2\.5/.test(modelId)) return "gemini-2.5-pro";
+  return "unknown";
+}
+
+/**
+ * @param {string|undefined} level
+ * @param {string|null|undefined} modelId
+ * @returns {ThinkingConfig}
+ */
+export function resolveThinkingConfig(level, modelId) {
+  if (level === undefined) {
+    return { thinkingLevel: undefined, thinkingBudget: undefined, notes: [] };
+  }
+  if (!LEVEL_SET.has(level)) {
+    throw new Error(`Invalid thinking level: ${level}. Expected one of ${THINKING_LEVELS.join(", ")}.`);
+  }
+
+  const family = detectFamily(modelId);
+  const notes = [];
+
+  if (family === "unknown") {
+    notes.push("unknown model family; thinking config not delivered");
+    return { thinkingLevel: undefined, thinkingBudget: undefined, notes };
+  }
+
+  if (family === "gemini-3") {
+    if (level === "off") {
+      notes.push("clamped off→low: Gemini 3 does not support zero thinking");
+      return { thinkingLevel: "low", thinkingBudget: undefined, notes };
+    }
+    if (level === "low") return { thinkingLevel: "low", thinkingBudget: undefined, notes };
+    if (level === "high") return { thinkingLevel: "high", thinkingBudget: undefined, notes };
+    // medium: no explicit level; Gemini 3 uses its own dynamic default.
+    return { thinkingLevel: undefined, thinkingBudget: undefined, notes };
+  }
+
+  if (family === "gemini-2.5-pro") {
+    if (level === "off") {
+      notes.push("clamped off→low: Gemini 2.5 Pro minimum thinkingBudget is 128");
+      return { thinkingLevel: undefined, thinkingBudget: 2048, notes };
+    }
+    if (level === "low") return { thinkingLevel: undefined, thinkingBudget: 2048, notes };
+    if (level === "medium") return { thinkingLevel: undefined, thinkingBudget: -1, notes };
+    if (level === "high") return { thinkingLevel: undefined, thinkingBudget: 24576, notes };
+  }
+
+  if (family === "gemini-2.5-flash" || family === "gemini-2.5-flash-lite") {
+    if (level === "off") return { thinkingLevel: undefined, thinkingBudget: 0, notes };
+    if (level === "low") return { thinkingLevel: undefined, thinkingBudget: 2048, notes };
+    if (level === "medium") return { thinkingLevel: undefined, thinkingBudget: -1, notes };
+    if (level === "high") return { thinkingLevel: undefined, thinkingBudget: 24576, notes };
+  }
+
+  return { thinkingLevel: undefined, thinkingBudget: undefined, notes };
+}

--- a/tests/acp-protocol.test.mjs
+++ b/tests/acp-protocol.test.mjs
@@ -5,7 +5,9 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(__dirname, "..");
 const LIB_DIR = path.resolve(__dirname, "..", "plugins", "gemini", "scripts", "lib");
+const DTS_PATH = path.join(ROOT_DIR, "plugins", "gemini", "scripts", "lib", "acp-protocol.d.ts");
 
 const GEMINI_MJS = fs.readFileSync(path.join(LIB_DIR, "gemini.mjs"), "utf8");
 const ACP_PROTOCOL_DTS = fs.readFileSync(path.join(LIB_DIR, "acp-protocol.d.ts"), "utf8");
@@ -51,4 +53,20 @@ test("every session/* method called at runtime is declared in acp-protocol.d.ts"
       `acp-protocol.d.ts is missing a declaration for ${method}`
     );
   }
+});
+
+test("acp-protocol.d.ts models SessionUpdateNotification with thought and message chunks", () => {
+  const source = fs.readFileSync(DTS_PATH, "utf8");
+  assert.match(source, /SessionUpdateNotification/);
+  assert.match(source, /agent_message_chunk/);
+  assert.match(source, /agent_thought_chunk/);
+  assert.match(source, /session\/update/);
+});
+
+test("acp-protocol.d.ts no longer defines the stale progress/toolCall/fileChange/error AcpNotification union", () => {
+  const source = fs.readFileSync(DTS_PATH, "utf8");
+  assert.doesNotMatch(source, /method:\s*"progress"/);
+  assert.doesNotMatch(source, /method:\s*"toolCall"/);
+  assert.doesNotMatch(source, /method:\s*"fileChange"/);
+  assert.doesNotMatch(source, /method:\s*"error"/);
 });

--- a/tests/acp-protocol.test.mjs
+++ b/tests/acp-protocol.test.mjs
@@ -5,9 +5,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const ROOT_DIR = path.resolve(__dirname, "..");
 const LIB_DIR = path.resolve(__dirname, "..", "plugins", "gemini", "scripts", "lib");
-const DTS_PATH = path.join(ROOT_DIR, "plugins", "gemini", "scripts", "lib", "acp-protocol.d.ts");
 
 const GEMINI_MJS = fs.readFileSync(path.join(LIB_DIR, "gemini.mjs"), "utf8");
 const ACP_PROTOCOL_DTS = fs.readFileSync(path.join(LIB_DIR, "acp-protocol.d.ts"), "utf8");
@@ -56,17 +54,27 @@ test("every session/* method called at runtime is declared in acp-protocol.d.ts"
 });
 
 test("acp-protocol.d.ts models SessionUpdateNotification with thought and message chunks", () => {
-  const source = fs.readFileSync(DTS_PATH, "utf8");
-  assert.match(source, /SessionUpdateNotification/);
-  assert.match(source, /agent_message_chunk/);
-  assert.match(source, /agent_thought_chunk/);
-  assert.match(source, /session\/update/);
+  assert.match(ACP_PROTOCOL_DTS, /SessionUpdateNotification/);
+  assert.match(ACP_PROTOCOL_DTS, /agent_message_chunk/);
+  assert.match(ACP_PROTOCOL_DTS, /agent_thought_chunk/);
+  assert.match(ACP_PROTOCOL_DTS, /session\/update/);
 });
 
 test("acp-protocol.d.ts no longer defines the stale progress/toolCall/fileChange/error AcpNotification union", () => {
-  const source = fs.readFileSync(DTS_PATH, "utf8");
-  assert.doesNotMatch(source, /method:\s*"progress"/);
-  assert.doesNotMatch(source, /method:\s*"toolCall"/);
-  assert.doesNotMatch(source, /method:\s*"fileChange"/);
-  assert.doesNotMatch(source, /method:\s*"error"/);
+  assert.doesNotMatch(ACP_PROTOCOL_DTS, /method:\s*"progress"/);
+  assert.doesNotMatch(ACP_PROTOCOL_DTS, /method:\s*"toolCall"/);
+  assert.doesNotMatch(ACP_PROTOCOL_DTS, /method:\s*"fileChange"/);
+  assert.doesNotMatch(ACP_PROTOCOL_DTS, /method:\s*"error"/);
+});
+
+test("acp-protocol.d.ts shares text chunk content type across message and thought chunks", () => {
+  assert.match(ACP_PROTOCOL_DTS, /interface AgentChunkContent/);
+  assert.match(ACP_PROTOCOL_DTS, /AgentMessageChunkUpdate[\s\S]*content:\s*AgentChunkContent/);
+  assert.match(ACP_PROTOCOL_DTS, /AgentThoughtChunkUpdate[\s\S]*content:\s*AgentChunkContent/);
+  assert.doesNotMatch(ACP_PROTOCOL_DTS, /interface AgentMessageChunkContent/);
+  assert.doesNotMatch(ACP_PROTOCOL_DTS, /interface AgentThoughtChunkContent/);
+});
+
+test("FileChangeUpdate action matches FileChangeRecord action literals", () => {
+  assert.match(ACP_PROTOCOL_DTS, /interface FileChangeUpdate[\s\S]*action:\s*"create"\s*\|\s*"modify"\s*\|\s*"delete"/);
 });

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -3,6 +3,7 @@ import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
 import { fileURLToPath } from "node:url";
+import { initGitRepo, makeTempDir, run } from "./helpers.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const PLUGIN_ROOT = path.join(ROOT, "plugins", "gemini");
@@ -213,4 +214,23 @@ test("gemini-result-handling skill forbids fabricating results for incomplete jo
   assert.match(resultHandling, /do not fabricate|do not invent|never fabricate/i);
   assert.match(resultHandling, /incomplete|non-terminal|still running|in progress/i);
   assert.match(resultHandling, /\/gemini:(status|cancel|result)/);
+});
+
+test("companion task rejects an invalid --thinking value with exit 1 and usage", () => {
+  const cwd = makeTempDir();
+  initGitRepo(cwd);
+  const result = run(process.execPath, [COMPANION_SCRIPT, "task", "--thinking", "purple", "--", "noop"], {
+    cwd,
+    env: { ...process.env, PATH: process.env.PATH }
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /invalid --thinking value/i);
+  assert.match(result.stderr, /off.*low.*medium.*high|off, low, medium, high/);
+});
+
+test("companion --help mentions --thinking and --stream-output", () => {
+  const result = run(process.execPath, [COMPANION_SCRIPT, "--help"], {});
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /--thinking <off\|low\|medium\|high>/);
+  assert.match(result.stdout, /--stream-output/);
 });

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -225,7 +225,7 @@ test("companion task rejects an invalid --thinking value with exit 1 and usage",
   });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /invalid --thinking value/i);
-  assert.match(result.stderr, /off.*low.*medium.*high|off, low, medium, high/);
+  assert.match(result.stderr, /off.*low.*medium.*high/);
 });
 
 test("companion --help mentions --thinking and --stream-output", () => {

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -56,15 +56,16 @@ test("rescue command uses inline execution without subagent delegation", () => {
   assert.match(rescue, /--background\|--wait/);
   assert.match(rescue, /--resume\|--fresh/);
   assert.match(rescue, /--model auto-gemini-3\|auto-gemini-2\.5\|pro\|flash\|flash-lite\|/);
-  assert.match(rescue, /--thinking-budget <number>/);
+  assert.match(rescue, /--thinking <off\|low\|medium\|high>/);
+  assert.match(rescue, /--stream-output/);
   assert.match(rescue, /task-resume-candidate --json/);
   assert.match(rescue, /AskUserQuestion/);
   assert.match(rescue, /Continue current Gemini thread/);
   assert.match(rescue, /Start a new Gemini thread/);
   assert.match(rescue, /default to foreground/i);
   assert.match(rescue, /Do not forward them to `task`/i);
-  assert.match(rescue, /`--model` and `--thinking-budget` are runtime-selection flags/i);
-  assert.match(rescue, /Leave `--thinking-budget` unset unless the user explicitly asks/i);
+  assert.match(rescue, /`--model`, `--thinking`, and `--stream-output` are runtime-selection flags/i);
+  assert.match(rescue, /Leave `--thinking` unset unless the user explicitly asks/i);
   assert.match(rescue, /The default model is `auto-gemini-3`/i);
   assert.match(rescue, /auto-gemini-2\.5/i);
   assert.match(rescue, /If the request includes `--resume`, do not ask whether to continue/i);
@@ -82,7 +83,7 @@ test("rescue command uses inline execution without subagent delegation", () => {
   assert.match(agent, /Use exactly one `Bash` call/i);
   assert.match(agent, /Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own/i);
   assert.match(agent, /Do not call `review`, `adversarial-review`, `status`, `result`, or `cancel`/i);
-  assert.match(agent, /Leave `--thinking-budget` unset unless the user explicitly requests a specific thinking budget/i);
+  assert.match(agent, /Leave `--thinking` unset unless the user explicitly requests a specific thinking level/i);
   assert.match(agent, /The default model is `auto-gemini-3`/i);
   assert.match(agent, /auto-gemini-2\.5/i);
   assert.match(agent, /\bpro\b/i);

--- a/tests/docs-agreement.test.mjs
+++ b/tests/docs-agreement.test.mjs
@@ -1,0 +1,30 @@
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const RESCUE = fs.readFileSync(path.join(ROOT, "plugins/gemini/commands/rescue.md"), "utf8");
+const REVIEW = fs.readFileSync(path.join(ROOT, "plugins/gemini/commands/review.md"), "utf8");
+
+test("rescue.md advertises --thinking <off|low|medium|high>", () => {
+  assert.match(RESCUE, /--thinking <off\|low\|medium\|high>/);
+});
+
+test("rescue.md advertises --stream-output", () => {
+  assert.match(RESCUE, /--stream-output/);
+});
+
+test("rescue.md no longer advertises the broken --thinking-budget <number> form", () => {
+  assert.doesNotMatch(RESCUE, /--thinking-budget\s*<number>/);
+});
+
+test("review.md advertises --thinking and --stream-output", () => {
+  assert.match(REVIEW, /--thinking <off\|low\|medium\|high>/);
+  assert.match(REVIEW, /--stream-output/);
+});
+
+test("review.md no longer advertises the broken --thinking-budget <number> form", () => {
+  assert.doesNotMatch(REVIEW, /--thinking-budget\s*<number>/);
+});

--- a/tests/docs-agreement.test.mjs
+++ b/tests/docs-agreement.test.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const RESCUE = fs.readFileSync(path.join(ROOT, "plugins/gemini/commands/rescue.md"), "utf8");
 const REVIEW = fs.readFileSync(path.join(ROOT, "plugins/gemini/commands/review.md"), "utf8");
+const RESCUE_AGENT = fs.readFileSync(path.join(ROOT, "plugins/gemini/agents/gemini-rescue.md"), "utf8");
 const README = fs.readFileSync(path.join(ROOT, "README.md"), "utf8");
 
 test("rescue.md advertises --thinking <off|low|medium|high>", () => {
@@ -34,6 +35,27 @@ test("README documents --thinking levels and default", () => {
   assert.match(README, /--thinking <off\|low\|medium\|high>/);
   assert.match(README, /medium/i);
   assert.match(README, /default/i);
+});
+
+test("docs explain --thinking is parsed but not delivered per invocation yet", () => {
+  for (const [name, source] of [
+    ["README.md", README],
+    ["commands/rescue.md", RESCUE],
+    ["commands/review.md", REVIEW],
+    ["agents/gemini-rescue.md", RESCUE_AGENT]
+  ]) {
+    assert.match(source, /per-invocation thinking override/i, `${name} should mention the runtime limitation`);
+    assert.match(source, /one-?shot|one-?time/i, `${name} should mention the warning`);
+    assert.match(source, /settings\.json/i, `${name} should point at persistent settings`);
+  }
+});
+
+test("README thinking section uses t-shirt-sized and tagged progress fences", () => {
+  assert.match(README, /t-shirt-sized/);
+  assert.doesNotMatch(README, /t-shirt sized/);
+  assert.match(README, /```text\n\[session\] created/);
+  assert.match(README, /```text\n\[session\] created\n\[tool\] read_file\nHere's what I found/);
+  assert.match(README, /```text\nRunning jobs \(1\):/);
 });
 
 test("README documents --stream-output and compact markers default", () => {

--- a/tests/docs-agreement.test.mjs
+++ b/tests/docs-agreement.test.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const RESCUE = fs.readFileSync(path.join(ROOT, "plugins/gemini/commands/rescue.md"), "utf8");
 const REVIEW = fs.readFileSync(path.join(ROOT, "plugins/gemini/commands/review.md"), "utf8");
+const README = fs.readFileSync(path.join(ROOT, "README.md"), "utf8");
 
 test("rescue.md advertises --thinking <off|low|medium|high>", () => {
   assert.match(RESCUE, /--thinking <off\|low\|medium\|high>/);
@@ -27,4 +28,19 @@ test("review.md advertises --thinking and --stream-output", () => {
 
 test("review.md no longer advertises the broken --thinking-budget <number> form", () => {
   assert.doesNotMatch(REVIEW, /--thinking-budget\s*<number>/);
+});
+
+test("README documents --thinking levels and default", () => {
+  assert.match(README, /--thinking <off\|low\|medium\|high>/);
+  assert.match(README, /medium/i);
+  assert.match(README, /default/i);
+});
+
+test("README documents --stream-output and compact markers default", () => {
+  assert.match(README, /--stream-output/);
+  assert.match(README, /compact markers|\[tool\]|\[thinking\]|live progress/i);
+});
+
+test("README documents the /gemini:status event tail view", () => {
+  assert.match(README, /event tail|recent events|last event/i);
 });

--- a/tests/gemini-companion-flags.test.mjs
+++ b/tests/gemini-companion-flags.test.mjs
@@ -1,0 +1,33 @@
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const COMPANION_SRC = fs.readFileSync(path.join(ROOT, "plugins/gemini/scripts/gemini-companion.mjs"), "utf8");
+
+test("printUsage lists --thinking and --stream-output on task invocation", () => {
+  assert.match(COMPANION_SRC, /--thinking <off\|low\|medium\|high>/);
+  assert.match(COMPANION_SRC, /--stream-output/);
+});
+
+test("printUsage no longer advertises the broken --thinking-budget <number> flag", () => {
+  assert.doesNotMatch(COMPANION_SRC, /--thinking-budget\s*<number>/);
+});
+
+test("handleTask parses --thinking as a value option and --stream-output as a boolean option", () => {
+  assert.match(COMPANION_SRC, /handleTask[\s\S]{0,1200}valueOptions:\s*\[[^\]]*"thinking"/);
+  assert.match(COMPANION_SRC, /handleTask[\s\S]{0,1200}booleanOptions:\s*\[[^\]]*"stream-output"/);
+});
+
+test("handleTask validates --thinking against the THINKING_LEVELS set", () => {
+  assert.match(COMPANION_SRC, /THINKING_LEVELS/);
+});
+
+test("handleReview and handleReviewCommand also parse --thinking and --stream-output", () => {
+  assert.match(COMPANION_SRC, /handleReview\b[\s\S]{0,1200}valueOptions:\s*\[[^\]]*"thinking"/);
+  assert.match(COMPANION_SRC, /handleReview\b[\s\S]{0,1200}booleanOptions:\s*\[[^\]]*"stream-output"/);
+  assert.match(COMPANION_SRC, /handleReviewCommand[\s\S]{0,1200}valueOptions:\s*\[[^\]]*"thinking"/);
+  assert.match(COMPANION_SRC, /handleReviewCommand[\s\S]{0,1200}booleanOptions:\s*\[[^\]]*"stream-output"/);
+});

--- a/tests/gemini-companion-flags.test.mjs
+++ b/tests/gemini-companion-flags.test.mjs
@@ -7,6 +7,25 @@ import { fileURLToPath } from "node:url";
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const COMPANION_SRC = fs.readFileSync(path.join(ROOT, "plugins/gemini/scripts/gemini-companion.mjs"), "utf8");
 
+function functionSource(name) {
+  const marker = `async function ${name}`;
+  const start = COMPANION_SRC.indexOf(marker);
+  assert.notEqual(start, -1, `missing ${name}`);
+  const paramsEnd = COMPANION_SRC.indexOf(") {", start);
+  assert.notEqual(paramsEnd, -1, `missing ${name} body`);
+  const open = paramsEnd + 2;
+  let depth = 0;
+  for (let i = open; i < COMPANION_SRC.length; i++) {
+    const ch = COMPANION_SRC[i];
+    if (ch === "{") depth += 1;
+    if (ch === "}") {
+      depth -= 1;
+      if (depth === 0) return COMPANION_SRC.slice(start, i + 1);
+    }
+  }
+  assert.fail(`could not extract ${name}`);
+}
+
 test("printUsage lists --thinking and --stream-output on task invocation", () => {
   assert.match(COMPANION_SRC, /--thinking <off\|low\|medium\|high>/);
   assert.match(COMPANION_SRC, /--stream-output/);
@@ -17,8 +36,9 @@ test("printUsage no longer advertises the broken --thinking-budget <number> flag
 });
 
 test("handleTask parses --thinking as a value option and --stream-output as a boolean option", () => {
-  assert.match(COMPANION_SRC, /handleTask[\s\S]{0,1200}valueOptions:\s*\[[^\]]*"thinking"/);
-  assert.match(COMPANION_SRC, /handleTask[\s\S]{0,1200}booleanOptions:\s*\[[^\]]*"stream-output"/);
+  const body = functionSource("handleTask");
+  assert.match(body, /valueOptions:\s*\[[^\]]*"thinking"/);
+  assert.match(body, /booleanOptions:\s*\[[^\]]*"stream-output"/);
 });
 
 test("handleTask validates --thinking against the THINKING_LEVELS set", () => {
@@ -26,8 +46,19 @@ test("handleTask validates --thinking against the THINKING_LEVELS set", () => {
 });
 
 test("handleReview and handleReviewCommand also parse --thinking and --stream-output", () => {
-  assert.match(COMPANION_SRC, /handleReview\b[\s\S]{0,1200}valueOptions:\s*\[[^\]]*"thinking"/);
-  assert.match(COMPANION_SRC, /handleReview\b[\s\S]{0,1200}booleanOptions:\s*\[[^\]]*"stream-output"/);
-  assert.match(COMPANION_SRC, /handleReviewCommand[\s\S]{0,1200}valueOptions:\s*\[[^\]]*"thinking"/);
-  assert.match(COMPANION_SRC, /handleReviewCommand[\s\S]{0,1200}booleanOptions:\s*\[[^\]]*"stream-output"/);
+  for (const name of ["handleReview", "handleReviewCommand"]) {
+    const body = functionSource(name);
+    assert.match(body, /valueOptions:\s*\[[^\]]*"thinking"/);
+    assert.match(body, /booleanOptions:\s*\[[^\]]*"stream-output"/);
+  }
+});
+
+test("foreground task done stats use returned chunk counters and only emit after errors are checked", () => {
+  const body = functionSource("handleTask");
+  assert.match(body, /chunks:\s*result\.chunkCount\s*\?\?\s*0/);
+  assert.doesNotMatch(body, /chunks:\s*0/);
+  assert.ok(
+    body.indexOf("if (result.error)") < body.indexOf('type: "done"'),
+    "done marker should not be emitted before a failed run throws"
+  );
 });

--- a/tests/gemini-streaming.test.mjs
+++ b/tests/gemini-streaming.test.mjs
@@ -1,0 +1,43 @@
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+import { __testing as gemini } from "../plugins/gemini/scripts/lib/gemini.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const GEMINI_SOURCE = fs.readFileSync(path.join(ROOT, "plugins/gemini/scripts/lib/gemini.mjs"), "utf8");
+
+test("simulateNotificationDispatch accumulates text and thoughtText distinctly", () => {
+  const { text, thoughtText, events } = gemini.simulateNotificationDispatch([
+    { method: "session/update", params: { sessionId: "s", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Hello" } } } },
+    { method: "session/update", params: { sessionId: "s", update: { sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "thinking" } } } },
+    { method: "session/update", params: { sessionId: "s", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: ", world" } } } }
+  ]);
+  assert.equal(text, "Hello, world");
+  assert.equal(thoughtText, "thinking");
+  const kinds = events.map((e) => e.type);
+  assert.deepEqual(kinds, ["message_chunk", "thought_chunk", "message_chunk"]);
+});
+
+test("simulateNotificationDispatch fires tool_call and file_change as stream events", () => {
+  const { events } = gemini.simulateNotificationDispatch([
+    { method: "session/update", params: { sessionId: "s", update: { sessionUpdate: "tool_call", toolName: "read_file" } } },
+    { method: "session/update", params: { sessionId: "s", update: { sessionUpdate: "file_change", path: "a.mjs", action: "write" } } }
+  ]);
+  assert.deepEqual(events.map((e) => e.type), ["tool_call", "file_change"]);
+  assert.equal(events[0].toolName, "read_file");
+  assert.equal(events[1].path, "a.mjs");
+  assert.equal(events[1].action, "write");
+});
+
+test("runAcpReview forwards thinking and onStream to runAcpPrompt", () => {
+  assert.match(GEMINI_SOURCE, /runAcpReview[\s\S]{0,1500}thinking:\s*options\.thinking/);
+  assert.match(GEMINI_SOURCE, /runAcpReview[\s\S]{0,1500}onStream:\s*options\.onStream/);
+});
+
+test("runAcpAdversarialReview forwards thinking and onStream to runAcpPrompt", () => {
+  assert.match(GEMINI_SOURCE, /runAcpAdversarialReview[\s\S]{0,2500}thinking:\s*options\.thinking/);
+  assert.match(GEMINI_SOURCE, /runAcpAdversarialReview[\s\S]{0,2500}onStream:\s*options\.onStream/);
+});

--- a/tests/gemini-streaming.test.mjs
+++ b/tests/gemini-streaming.test.mjs
@@ -10,13 +10,14 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const GEMINI_SOURCE = fs.readFileSync(path.join(ROOT, "plugins/gemini/scripts/lib/gemini.mjs"), "utf8");
 
 test("simulateNotificationDispatch keeps thought text out of returned data by default", () => {
-  const { text, thoughtText, events } = gemini.simulateNotificationDispatch([
+  const { text, thoughtText, chunkCount, events } = gemini.simulateNotificationDispatch([
     { method: "session/update", params: { sessionId: "s", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Hello" } } } },
     { method: "session/update", params: { sessionId: "s", update: { sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "thinking" } } } },
     { method: "session/update", params: { sessionId: "s", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: ", world" } } } }
   ]);
   assert.equal(text, "Hello, world");
   assert.equal(thoughtText, "");
+  assert.equal(chunkCount, 2);
   const kinds = events.map((e) => e.type);
   assert.deepEqual(kinds, ["message_chunk", "thought_chunk", "message_chunk"]);
   assert.equal(events[1].text, undefined);
@@ -62,12 +63,32 @@ test("simulateNotificationDispatch fires tool_call and file_change as stream eve
   assert.equal(events[1].action, "write");
 });
 
+function functionSource(name) {
+  const start = GEMINI_SOURCE.indexOf(`export async function ${name}`);
+  assert.notEqual(start, -1, `missing ${name}`);
+  const paramsEnd = GEMINI_SOURCE.indexOf(") {", start);
+  assert.notEqual(paramsEnd, -1, `missing ${name} body`);
+  const open = paramsEnd + 2;
+  let depth = 0;
+  for (let i = open; i < GEMINI_SOURCE.length; i++) {
+    const ch = GEMINI_SOURCE[i];
+    if (ch === "{") depth += 1;
+    if (ch === "}") {
+      depth -= 1;
+      if (depth === 0) return GEMINI_SOURCE.slice(start, i + 1);
+    }
+  }
+  assert.fail(`could not extract ${name}`);
+}
+
 test("runAcpReview forwards thinking and onStream to runAcpPrompt", () => {
-  assert.match(GEMINI_SOURCE, /runAcpReview[\s\S]{0,1500}thinking:\s*options\.thinking/);
-  assert.match(GEMINI_SOURCE, /runAcpReview[\s\S]{0,1500}onStream:\s*options\.onStream/);
+  const body = functionSource("runAcpReview");
+  assert.match(body, /thinking:\s*options\.thinking/);
+  assert.match(body, /onStream:\s*options\.onStream/);
 });
 
 test("runAcpAdversarialReview forwards thinking and onStream to runAcpPrompt", () => {
-  assert.match(GEMINI_SOURCE, /runAcpAdversarialReview[\s\S]{0,2500}thinking:\s*options\.thinking/);
-  assert.match(GEMINI_SOURCE, /runAcpAdversarialReview[\s\S]{0,2500}onStream:\s*options\.onStream/);
+  const body = functionSource("runAcpAdversarialReview");
+  assert.match(body, /thinking:\s*options\.thinking/);
+  assert.match(body, /onStream:\s*options\.onStream/);
 });

--- a/tests/gemini-streaming.test.mjs
+++ b/tests/gemini-streaming.test.mjs
@@ -9,16 +9,46 @@ import { __testing as gemini } from "../plugins/gemini/scripts/lib/gemini.mjs";
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const GEMINI_SOURCE = fs.readFileSync(path.join(ROOT, "plugins/gemini/scripts/lib/gemini.mjs"), "utf8");
 
-test("simulateNotificationDispatch accumulates text and thoughtText distinctly", () => {
+test("simulateNotificationDispatch keeps thought text out of returned data by default", () => {
   const { text, thoughtText, events } = gemini.simulateNotificationDispatch([
     { method: "session/update", params: { sessionId: "s", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Hello" } } } },
     { method: "session/update", params: { sessionId: "s", update: { sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "thinking" } } } },
     { method: "session/update", params: { sessionId: "s", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: ", world" } } } }
   ]);
   assert.equal(text, "Hello, world");
-  assert.equal(thoughtText, "thinking");
+  assert.equal(thoughtText, "");
   const kinds = events.map((e) => e.type);
   assert.deepEqual(kinds, ["message_chunk", "thought_chunk", "message_chunk"]);
+  assert.equal(events[1].text, undefined);
+  assert.equal(events[1].chars, "thinking".length);
+});
+
+test("simulateNotificationDispatch streams thought text only when explicitly requested", () => {
+  const streamed = [];
+  const { thoughtText, thoughtCount, thoughtChars } = gemini.simulateNotificationDispatch([
+    { method: "session/update", params: { sessionId: "s", update: { sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "thinking" } } } }
+  ], (event) => streamed.push(event), { streamThoughtText: true });
+
+  assert.equal(thoughtText, "");
+  assert.equal(thoughtCount, 1);
+  assert.equal(thoughtChars, "thinking".length);
+  assert.equal(streamed[0].type, "thought_chunk");
+  assert.equal(streamed[0].text, "thinking");
+});
+
+test("simulateNotificationDispatch sanitizes diagnostic stream event fields", () => {
+  const streamed = [];
+  const { events } = gemini.simulateNotificationDispatch([
+    { method: "session/update", params: { sessionId: "s", update: { sessionUpdate: "tool_call", toolName: "read\u001b[2J_file\n[done] forged" } } },
+    { method: "session/update", params: { sessionId: "s", update: { sessionUpdate: "file_change", path: "src/\u001b]52;c;bad\u0007x\n[phase] forged", action: "write\u001b[H\n[tool] forged" } } }
+  ], (event) => streamed.push(event));
+
+  assert.deepEqual(events, streamed);
+  const encoded = JSON.stringify(events);
+  assert.doesNotMatch(encoded, /[\u001b\u0007]/);
+  assert.equal(events[0].toolName, "read_file [done] forged");
+  assert.equal(events[1].path, "src/x [phase] forged");
+  assert.equal(events[1].action, "write [tool] forged");
 });
 
 test("simulateNotificationDispatch fires tool_call and file_change as stream events", () => {

--- a/tests/job-observability.test.mjs
+++ b/tests/job-observability.test.mjs
@@ -481,3 +481,38 @@ test("concurrent recordJobEvent calls on the same job retain all events", async 
     assert.ok(observed.has(`chunk-${i}`), `event chunk-${i} missing`);
   }
 });
+
+test("buildJobEventFromAcpNotification distinguishes agent_thought_chunk from agent_message_chunk", async () => {
+  const messageEvent = buildJobEventFromAcpNotification({
+    method: "session/update",
+    params: { sessionId: "s1", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "hello" } } }
+  });
+  const thoughtEvent = buildJobEventFromAcpNotification({
+    method: "session/update",
+    params: { sessionId: "s1", update: { sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "reasoning" } } }
+  });
+  assert.equal(messageEvent.type, "model_text_chunk");
+  assert.equal(messageEvent.chars, 5);
+  assert.equal(thoughtEvent.type, "model_thought_chunk");
+  assert.equal(thoughtEvent.chars, 9);
+  assert.equal(messageEvent.text, undefined);
+  assert.equal(thoughtEvent.text, undefined);
+});
+
+test("recordJobEvent persists model_thought_chunk with only char count", async () => {
+  const workspace = makeTempDir();
+  initGitRepo(workspace);
+  const job = await createTrackedJob({ workspaceRoot: workspace, kind: "task", title: "thought persist" });
+
+  await recordJobEvent(workspace, job.id, {
+    type: "model_thought_chunk",
+    chars: 42,
+    timestamp: new Date("2026-04-18T12:00:00Z").toISOString()
+  });
+
+  const stored = readJobFile(workspace, job.id);
+  const last = stored.events.at(-1);
+  assert.equal(last.type, "model_thought_chunk");
+  assert.equal(last.chars, 42);
+  assert.equal(last.text, undefined);
+});

--- a/tests/job-observability.test.mjs
+++ b/tests/job-observability.test.mjs
@@ -507,6 +507,7 @@ test("recordJobEvent persists model_thought_chunk with only char count", async (
   await recordJobEvent(workspace, job.id, {
     type: "model_thought_chunk",
     chars: 42,
+    text: "sensitive thought trace",
     timestamp: new Date("2026-04-18T12:00:00Z").toISOString()
   });
 
@@ -515,4 +516,5 @@ test("recordJobEvent persists model_thought_chunk with only char count", async (
   assert.equal(last.type, "model_thought_chunk");
   assert.equal(last.chars, 42);
   assert.equal(last.text, undefined);
+  assert.equal(JSON.stringify(stored).includes("sensitive thought trace"), false);
 });

--- a/tests/render.test.mjs
+++ b/tests/render.test.mjs
@@ -197,3 +197,51 @@ test("renderSingleJobStatus includes runtime.transport when present", () => {
   assert.match(output, /## Runtime/);
   assert.match(output, /- \*\*Transport:\*\* broker/);
 });
+
+test("renderSingleJobStatus includes tail of recent events and counters", () => {
+  const now = Date.parse("2026-04-18T12:00:10.000Z");
+  const job = {
+    id: "job_abc",
+    kind: "task",
+    status: "running",
+    title: "observing",
+    startedAt: "2026-04-18T12:00:00.000Z",
+    events: [
+      { type: "phase", message: "session_created", timestamp: "2026-04-18T12:00:01.000Z" },
+      { type: "tool_call", toolName: "read_file", timestamp: "2026-04-18T12:00:02.000Z" },
+      { type: "model_text_chunk", chars: 140, timestamp: "2026-04-18T12:00:03.000Z" },
+      { type: "model_thought_chunk", chars: 62, timestamp: "2026-04-18T12:00:04.000Z" },
+      { type: "model_text_chunk", chars: 85, timestamp: "2026-04-18T12:00:05.000Z" },
+      { type: "file_change", path: "a.mjs", action: "write", timestamp: "2026-04-18T12:00:06.000Z" },
+      { type: "tool_call", toolName: "write_file", timestamp: "2026-04-18T12:00:07.000Z" },
+      { type: "model_text_chunk", chars: 22, timestamp: "2026-04-18T12:00:08.000Z" }
+    ]
+  };
+
+  const rendered = renderSingleJobStatus(job, { now });
+
+  assert.match(rendered, /model_text_chunk.*22/);
+  assert.match(rendered, /tool_call.*write_file/);
+  assert.match(rendered, /file_change.*write.*a\.mjs/);
+  assert.match(rendered, /chunks=3/);
+  assert.match(rendered, /thoughts=1/);
+  assert.match(rendered, /tools=2/);
+  assert.match(rendered, /files=1/);
+  assert.match(rendered, /last event.*(ms|s) ago/i);
+  assert.doesNotMatch(rendered, /session_created/);
+});
+
+test("renderSingleJobStatus falls back to phase-only rendering when events is missing", () => {
+  const job = {
+    id: "job_fallback",
+    kind: "task",
+    status: "running",
+    title: "no events",
+    startedAt: "2026-04-18T12:00:00.000Z",
+    phase: "running"
+  };
+
+  const rendered = renderSingleJobStatus(job);
+  assert.match(rendered, /job_fallback/);
+  assert.doesNotMatch(rendered, /recent:/);
+});

--- a/tests/render.test.mjs
+++ b/tests/render.test.mjs
@@ -133,6 +133,7 @@ test("renderStatusSnapshot includes health and last progress for active jobs", (
 
 test("renderSingleJobStatus includes observability details without raw event payloads", () => {
   const output = renderSingleJobStatus({
+    workspaceRoot: "/tmp/test-workspace",
     job: {
       id: "gemini-detail",
       kind: "task",
@@ -183,6 +184,7 @@ test("renderSingleJobStatus includes observability details without raw event pay
 
 test("renderSingleJobStatus includes runtime.transport when present", () => {
   const output = renderSingleJobStatus({
+    workspaceRoot: "/tmp/test-workspace",
     job: {
       id: "gemini-transport",
       kind: "task",
@@ -229,6 +231,32 @@ test("renderSingleJobStatus includes tail of recent events and counters", () => 
   assert.match(rendered, /files=1/);
   assert.match(rendered, /last event.*(ms|s) ago/i);
   assert.doesNotMatch(rendered, /session_created/);
+  assert.doesNotMatch(rendered, /read_file/);
+});
+
+test("renderSingleJobStatus keeps event-tail details for phase changes and diagnostics", () => {
+  const now = Date.parse("2026-04-18T12:00:10.000Z");
+  const rendered = renderSingleJobStatus({
+    id: "job_events",
+    kind: "task",
+    status: "running",
+    title: "event formatting",
+    startedAt: "2026-04-18T12:00:00.000Z",
+    events: [
+      { type: "phase_changed", phase: "running", timestamp: "2026-04-18T12:00:06.000Z" },
+      { type: "diagnostic", message: "rate limit near", timestamp: "2026-04-18T12:00:07.000Z" },
+      { type: "diagnostic", source: "broker", message: "connected", timestamp: "2026-04-18T12:00:08.000Z" },
+      { type: "stderr", message: "warning text", timestamp: "2026-04-18T12:00:09.000Z" },
+      { type: "error", source: "gemini", message: "boom", timestamp: "2026-04-18T12:00:10.000Z" }
+    ]
+  }, { now });
+
+  assert.match(rendered, /\[phase_changed\] running/);
+  assert.match(rendered, /\[diagnostic\] rate limit near/);
+  assert.doesNotMatch(rendered, /unknown:/);
+  assert.match(rendered, /\[diagnostic\] broker: connected/);
+  assert.match(rendered, /\[stderr\] warning text/);
+  assert.match(rendered, /\[error\] gemini: boom/);
 });
 
 test("renderSingleJobStatus falls back to phase-only rendering when events is missing", () => {

--- a/tests/stream-output.test.mjs
+++ b/tests/stream-output.test.mjs
@@ -1,0 +1,113 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createStreamHandler, STREAM_MODES } from "../plugins/gemini/scripts/lib/stream-output.mjs";
+
+function captureWriter() {
+  const out = [];
+  return { writer: (s) => { out.push(s); return true; }, out };
+}
+
+test("STREAM_MODES enumerates the two accepted modes", () => {
+  assert.deepEqual(STREAM_MODES, ["markers", "passthrough"]);
+});
+
+test("markers mode prints session + tool + dot + thinking + file + done", () => {
+  const { writer, out } = captureWriter();
+  const handler = createStreamHandler({ mode: "markers", json: false, writer });
+  handler({ type: "phase", message: "session_created" });
+  handler({ type: "tool_call", toolName: "read_file" });
+  handler({ type: "message_chunk", text: "hello" });
+  handler({ type: "message_chunk", text: " world" });
+  handler({ type: "thought_chunk", text: "pondering" });
+  handler({ type: "file_change", path: "x.mjs", action: "write" });
+  handler({ type: "done", stats: { tools: 1, files: 1, chunks: 2, thoughts: 1, elapsedMs: 1200 } });
+  const joined = out.join("");
+  assert.match(joined, /\[session\] created/);
+  assert.match(joined, /\[tool\] read_file/);
+  assert.match(joined, /\.\./);
+  assert.match(joined, /\[thinking\]/);
+  assert.match(joined, /\[file\] write x\.mjs/);
+  assert.match(joined, /\[done\].*1\.2s.*1 tool.*1 file.*2 chunks.*1 thought/);
+});
+
+test("passthrough mode writes raw message and thought text", () => {
+  const { writer, out } = captureWriter();
+  const handler = createStreamHandler({ mode: "passthrough", json: false, writer });
+  handler({ type: "message_chunk", text: "Hello, " });
+  handler({ type: "message_chunk", text: "world." });
+  handler({ type: "thought_chunk", text: "I am reasoning." });
+  const joined = out.join("");
+  assert.match(joined, /Hello, world\./);
+  assert.match(joined, /thought: I am reasoning\./);
+});
+
+test("markers mode under json=true produces no output", () => {
+  const { writer, out } = captureWriter();
+  const handler = createStreamHandler({ mode: "markers", json: true, writer });
+  handler({ type: "tool_call", toolName: "read_file" });
+  handler({ type: "message_chunk", text: "x" });
+  assert.deepEqual(out, []);
+});
+
+test("passthrough mode under json=true still writes (user opted in)", () => {
+  const { writer, out } = captureWriter();
+  const handler = createStreamHandler({ mode: "passthrough", json: true, writer });
+  handler({ type: "message_chunk", text: "hi" });
+  assert.ok(out.length > 0);
+});
+
+test("writer EPIPE does not throw out of handler", () => {
+  const throwing = () => {
+    const err = new Error("EPIPE"); err.code = "EPIPE"; throw err;
+  };
+  const handler = createStreamHandler({ mode: "markers", json: false, writer: throwing });
+  assert.doesNotThrow(() => handler({ type: "tool_call", toolName: "x" }));
+});
+
+test("writer ERR_STREAM_DESTROYED does not throw out of handler", () => {
+  const throwing = () => {
+    const err = new Error("stream destroyed"); err.code = "ERR_STREAM_DESTROYED"; throw err;
+  };
+  const handler = createStreamHandler({ mode: "markers", json: false, writer: throwing });
+  assert.doesNotThrow(() => handler({ type: "tool_call", toolName: "x" }));
+});
+
+test("writer with unexpected error throws out of handler (does not silently swallow)", () => {
+  const throwing = () => {
+    throw new TypeError("writer broken");
+  };
+  const handler = createStreamHandler({ mode: "markers", json: false, writer: throwing });
+  assert.throws(() => handler({ type: "tool_call", toolName: "x" }), /writer broken/);
+});
+
+test("unknown event type is ignored safely", () => {
+  const { writer, out } = captureWriter();
+  const handler = createStreamHandler({ mode: "markers", json: false, writer });
+  handler({ type: "unknown" });
+  assert.deepEqual(out, []);
+});
+
+test("null or undefined event is ignored safely", () => {
+  const { writer, out } = captureWriter();
+  const handler = createStreamHandler({ mode: "markers", json: false, writer });
+  handler(null);
+  handler(undefined);
+  handler("not-an-object");
+  assert.deepEqual(out, []);
+});
+
+test("non-session phase messages render with [phase] label, not [session]", () => {
+  const { writer, out } = captureWriter();
+  const handler = createStreamHandler({ mode: "markers", json: false, writer });
+  handler({ type: "phase", message: "thinking:high" });
+  handler({ type: "phase", message: "session_loaded" });
+  const joined = out.join("");
+  assert.match(joined, /\[phase\] thinking:high/);
+  assert.match(joined, /\[session\] loaded/);
+  assert.doesNotMatch(joined, /\[session\] thinking:high/);
+});
+
+test("invalid mode throws", () => {
+  assert.throws(() => createStreamHandler({ mode: "nope", json: false, writer: () => {} }), /invalid stream mode/i);
+});

--- a/tests/stream-output.test.mjs
+++ b/tests/stream-output.test.mjs
@@ -31,6 +31,26 @@ test("markers mode prints session + tool + dot + thinking + file + done", () => 
   assert.match(joined, /\[done\].*1\.2s.*1 tool.*1 file.*2 chunks.*1 thought/);
 });
 
+test("markers mode sanitizes terminal controls and embedded newlines in marker fields", () => {
+  const { writer, out } = captureWriter();
+  const handler = createStreamHandler({ mode: "markers", json: false, writer });
+
+  handler({ type: "tool_call", toolName: "read\u001b[2J_file\n[done] forged" });
+  handler({
+    type: "file_change",
+    action: "write\u001b]52;c;SGVsbG8=\u0007\n[tool] forged",
+    path: "src/\u001b[Hdanger\n[phase] forged.mjs"
+  });
+
+  const joined = out.join("");
+  assert.doesNotMatch(joined, /[\u001b\u0007]/);
+
+  const lines = joined.trimEnd().split("\n");
+  assert.equal(lines.length, 2, "embedded newlines must not create forged marker lines");
+  assert.match(lines[0], /^\[tool\] read_file \[done\] forged$/);
+  assert.match(lines[1], /^\[file\] write \[tool\] forged src\/danger \[phase\] forged\.mjs$/);
+});
+
 test("passthrough mode writes raw message and thought text", () => {
   const { writer, out } = captureWriter();
   const handler = createStreamHandler({ mode: "passthrough", json: false, writer });

--- a/tests/thinking-warning.test.mjs
+++ b/tests/thinking-warning.test.mjs
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Task 10: runAcpPrompt emits a one-shot stderr warning when --thinking is
+// requested, since upstream Gemini CLI (0.38.x) does not expose a runtime
+// mechanism to deliver per-invocation thinking config. This test verifies
+// the warning fires exactly once per process by driving the same internal
+// code path the real flow uses — resolving thinking config and checking
+// the globalThis guard.
+
+import { resolveThinkingConfig } from "../plugins/gemini/scripts/lib/thinking.mjs";
+
+test("thinking warning guard fires exactly once per process", () => {
+  // Simulate what runAcpPrompt does in its thinking block.
+  function emitThinkingWarningIfNew(writer) {
+    if (!globalThis.__gemini_thinking_warned_test) {
+      writer(
+        "Warning: --thinking is parsed but not delivered to the running Gemini CLI. " +
+        "Configure thinkingConfig at the model-alias level in your Gemini settings.json " +
+        "for a persistent setting. See " +
+        "https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/generation-settings.md\n"
+      );
+      globalThis.__gemini_thinking_warned_test = true;
+    }
+  }
+
+  const out = [];
+  const writer = (s) => out.push(s);
+
+  // First invocation writes the warning.
+  emitThinkingWarningIfNew(writer);
+  assert.equal(out.length, 1);
+  assert.match(out[0], /--thinking is parsed but not delivered/);
+  assert.match(out[0], /settings\.json/);
+  assert.match(out[0], /generation-settings\.md/);
+
+  // Second and third invocations do NOT re-warn.
+  emitThinkingWarningIfNew(writer);
+  emitThinkingWarningIfNew(writer);
+  assert.equal(out.length, 1);
+
+  // Cleanup for other tests.
+  delete globalThis.__gemini_thinking_warned_test;
+});
+
+test("resolveThinkingConfig always returns a structured object even when delivery is not wired", () => {
+  // Parallel guarantee: even if the warning path triggers, the resolver
+  // still returns the structured config so observability + future delivery
+  // work when upstream adds a mechanism.
+  const resolved = resolveThinkingConfig("high", "gemini-3-pro");
+  assert.equal(resolved.thinkingLevel, "high");
+  assert.equal(resolved.thinkingBudget, undefined);
+  assert.deepEqual(resolved.notes, []);
+});

--- a/tests/thinking-warning.test.mjs
+++ b/tests/thinking-warning.test.mjs
@@ -8,39 +8,28 @@ import assert from "node:assert/strict";
 // code path the real flow uses — resolving thinking config and checking
 // the globalThis guard.
 
+import { __testing as gemini } from "../plugins/gemini/scripts/lib/gemini.mjs";
 import { resolveThinkingConfig } from "../plugins/gemini/scripts/lib/thinking.mjs";
 
 test("thinking warning guard fires exactly once per process", () => {
-  // Simulate what runAcpPrompt does in its thinking block.
-  function emitThinkingWarningIfNew(writer) {
-    if (!globalThis.__gemini_thinking_warned_test) {
-      writer(
-        "Warning: --thinking is parsed but not delivered to the running Gemini CLI. " +
-        "Configure thinkingConfig at the model-alias level in your Gemini settings.json " +
-        "for a persistent setting. See " +
-        "https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/generation-settings.md\n"
-      );
-      globalThis.__gemini_thinking_warned_test = true;
-    }
-  }
-
   const out = [];
   const writer = (s) => out.push(s);
 
   // First invocation writes the warning.
-  emitThinkingWarningIfNew(writer);
+  gemini.resetThinkingWarning();
+  gemini.emitThinkingWarningIfNew(writer);
   assert.equal(out.length, 1);
   assert.match(out[0], /--thinking is parsed but not delivered/);
   assert.match(out[0], /settings\.json/);
   assert.match(out[0], /generation-settings\.md/);
 
   // Second and third invocations do NOT re-warn.
-  emitThinkingWarningIfNew(writer);
-  emitThinkingWarningIfNew(writer);
+  gemini.emitThinkingWarningIfNew(writer);
+  gemini.emitThinkingWarningIfNew(writer);
   assert.equal(out.length, 1);
 
   // Cleanup for other tests.
-  delete globalThis.__gemini_thinking_warned_test;
+  gemini.resetThinkingWarning();
 });
 
 test("resolveThinkingConfig always returns a structured object even when delivery is not wired", () => {

--- a/tests/thinking.test.mjs
+++ b/tests/thinking.test.mjs
@@ -1,0 +1,110 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveThinkingConfig, THINKING_LEVELS } from "../plugins/gemini/scripts/lib/thinking.mjs";
+
+test("THINKING_LEVELS enumerates the four accepted levels in order", () => {
+  assert.deepEqual(THINKING_LEVELS, ["off", "low", "medium", "high"]);
+});
+
+test("resolveThinkingConfig returns empty config for undefined level (caller omitted flag)", () => {
+  const result = resolveThinkingConfig(undefined, "gemini-3-pro");
+  assert.deepEqual(result, { thinkingLevel: undefined, thinkingBudget: undefined, notes: [] });
+});
+
+test("resolveThinkingConfig maps Gemini 3 pro to thinkingLevel", () => {
+  assert.deepEqual(resolveThinkingConfig("low", "gemini-3-pro"), {
+    thinkingLevel: "low",
+    thinkingBudget: undefined,
+    notes: []
+  });
+  assert.deepEqual(resolveThinkingConfig("high", "gemini-3-pro"), {
+    thinkingLevel: "high",
+    thinkingBudget: undefined,
+    notes: []
+  });
+});
+
+test("resolveThinkingConfig recognizes Gemini 3 point releases like gemini-3.1-pro-preview", () => {
+  assert.deepEqual(resolveThinkingConfig("high", "gemini-3.1-pro-preview"), {
+    thinkingLevel: "high",
+    thinkingBudget: undefined,
+    notes: []
+  });
+  assert.deepEqual(resolveThinkingConfig("low", "gemini-3.1-flash-lite-preview"), {
+    thinkingLevel: "low",
+    thinkingBudget: undefined,
+    notes: []
+  });
+});
+
+test("resolveThinkingConfig medium on Gemini 3 leaves config empty (model dynamic default)", () => {
+  const result = resolveThinkingConfig("medium", "gemini-3-pro");
+  assert.deepEqual(result, { thinkingLevel: undefined, thinkingBudget: undefined, notes: [] });
+});
+
+test("resolveThinkingConfig off on Gemini 3 clamps to low with a note", () => {
+  const result = resolveThinkingConfig("off", "gemini-3-flash-preview");
+  assert.equal(result.thinkingLevel, "low");
+  assert.equal(result.thinkingBudget, undefined);
+  assert.match(result.notes[0], /clamped.*off.*low/i);
+});
+
+test("resolveThinkingConfig maps Gemini 2.5 flash to thinkingBudget numbers", () => {
+  assert.deepEqual(resolveThinkingConfig("off", "gemini-2.5-flash"), {
+    thinkingLevel: undefined,
+    thinkingBudget: 0,
+    notes: []
+  });
+  assert.deepEqual(resolveThinkingConfig("low", "gemini-2.5-flash"), {
+    thinkingLevel: undefined,
+    thinkingBudget: 2048,
+    notes: []
+  });
+  assert.deepEqual(resolveThinkingConfig("medium", "gemini-2.5-flash"), {
+    thinkingLevel: undefined,
+    thinkingBudget: -1,
+    notes: []
+  });
+  assert.deepEqual(resolveThinkingConfig("high", "gemini-2.5-flash"), {
+    thinkingLevel: undefined,
+    thinkingBudget: 24576,
+    notes: []
+  });
+});
+
+test("resolveThinkingConfig maps Gemini 2.5 flash-lite to the same thinkingBudget numbers as flash", () => {
+  assert.deepEqual(resolveThinkingConfig("off", "gemini-2.5-flash-lite"), {
+    thinkingLevel: undefined,
+    thinkingBudget: 0,
+    notes: []
+  });
+  assert.deepEqual(resolveThinkingConfig("high", "gemini-2.5-flash-lite"), {
+    thinkingLevel: undefined,
+    thinkingBudget: 24576,
+    notes: []
+  });
+});
+
+test("resolveThinkingConfig off on Gemini 2.5 pro clamps to low with a note (pro min is 128)", () => {
+  const result = resolveThinkingConfig("off", "gemini-2.5-pro");
+  assert.equal(result.thinkingBudget, 2048);
+  assert.equal(result.thinkingLevel, undefined);
+  assert.match(result.notes[0], /clamped.*off.*low/i);
+});
+
+test("resolveThinkingConfig on unknown model leaves config empty and adds a note", () => {
+  const result = resolveThinkingConfig("high", "some-new-model");
+  assert.equal(result.thinkingLevel, undefined);
+  assert.equal(result.thinkingBudget, undefined);
+  assert.match(result.notes[0], /unknown model family/i);
+});
+
+test("resolveThinkingConfig throws on invalid level", () => {
+  assert.throws(() => resolveThinkingConfig("purple", "gemini-3-pro"), /invalid thinking level/i);
+});
+
+test("resolveThinkingConfig accepts null modelId as unknown", () => {
+  const result = resolveThinkingConfig("medium", null);
+  assert.deepEqual(result, { thinkingLevel: undefined, thinkingBudget: undefined, notes: ["unknown model family; thinking config not delivered"] });
+});

--- a/tests/thinking.test.mjs
+++ b/tests/thinking.test.mjs
@@ -38,9 +38,11 @@ test("resolveThinkingConfig recognizes Gemini 3 point releases like gemini-3.1-p
   });
 });
 
-test("resolveThinkingConfig medium on Gemini 3 leaves config empty (model dynamic default)", () => {
+test("resolveThinkingConfig medium on Gemini 3 leaves config empty and reports model dynamic default", () => {
   const result = resolveThinkingConfig("medium", "gemini-3-pro");
-  assert.deepEqual(result, { thinkingLevel: undefined, thinkingBudget: undefined, notes: [] });
+  assert.equal(result.thinkingLevel, undefined);
+  assert.equal(result.thinkingBudget, undefined);
+  assert.match(result.notes[0], /gemini-3.*medium.*dynamic/i);
 });
 
 test("resolveThinkingConfig off on Gemini 3 clamps to low with a note", () => {
@@ -91,6 +93,8 @@ test("resolveThinkingConfig off on Gemini 2.5 pro clamps to low with a note (pro
   assert.equal(result.thinkingBudget, 2048);
   assert.equal(result.thinkingLevel, undefined);
   assert.match(result.notes[0], /clamped.*off.*low/i);
+  assert.match(result.notes[0], /2048/);
+  assert.match(result.notes[0], /minimum.*128/i);
 });
 
 test("resolveThinkingConfig on unknown model leaves config empty and adds a note", () => {


### PR DESCRIPTION
Fixes #15.

## Summary

- **Thought chunks are first-class.** `runAcpPrompt` now dispatches `agent_thought_chunk` distinctly from `agent_message_chunk`, accumulates a separate `thoughtText` return field, and records a dedicated `model_thought_chunk` event (chars only — privacy posture from PR #16 preserved for thoughts too).
- **Live progress in foreground runs.** New `lib/stream-output.mjs` factory produces a per-invocation stderr handler. Default is compact markers (`[session] created`, `[tool] name`, `.` per chunk, `[thinking]`, `[file] action path`, `[done] stats`). Opt in to raw passthrough with `--stream-output` — every message chunk and every thought chunk writes to stderr as it arrives, with a `thought: ` prefix on thoughts.
- **T-shirt sized thinking.** New `--thinking <off|low|medium|high>` flag (replaces the non-functional `--thinking-budget <number>` form in the old docs). Medium is the default. `lib/thinking.mjs` maps the categorical level to the right underlying Gemini parameter per model family — `thinkingLevel` for Gemini 3, `thinkingBudget` for Gemini 2.5 — with off→low clamping on models that can't zero-budget.
- **Spike outcome wired.** Local Gemini CLI 0.38.x does not expose a per-invocation thinking override (no CLI flag, no env var, no `session/new` param). Thinking config is a persistent setting in `settings.json` at the model-alias level. Rather than silently drop the flag, `runAcpPrompt` emits a one-shot stderr warning when `--thinking` is requested, pointing users at [upstream's persistent-settings docs](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/generation-settings.md). The resolver still returns the structured config so a future delivery mechanism is a one-line swap.
- **/gemini:status event tail.** `renderSingleJobStatus` now shows the last 5 events (sanitized fields only), rolled-up counters (`chunks/thoughts/tools/files`), and time-since-last-event. Falls back cleanly when the event log is absent.
- **Protocol types refreshed.** `lib/acp-protocol.d.ts` replaces the stale `AcpNotification` union (`progress`, `toolCall`, `fileChange`, `error` — none of which match the real runtime) with `SessionUpdateNotification` modeling `agent_message_chunk`, `agent_thought_chunk`, `tool_call`, `file_change`, plus `broker/diagnostic`.
- **Docs/runtime agreement enforced.** New `tests/docs-agreement.test.mjs` asserts `--thinking` and `--stream-output` are documented in rescue.md, review.md, and README, and that `--thinking-budget <number>` is gone. Docs and runtime cannot drift again.

## What changed

11 commits, 21 files, +1135/-48 lines.

**New modules**
- `plugins/gemini/scripts/lib/thinking.mjs` — pure level→config resolver with model-family detection and off→low clamping.
- `plugins/gemini/scripts/lib/stream-output.mjs` — stderr handler factory (markers / passthrough / JSON-aware suppression / EPIPE-safe).

**Modified source**
- `plugins/gemini/scripts/lib/gemini.mjs` — `runAcpPrompt` accepts `thinking` and `onStream`, returns `thoughtText`; distinguishes thought chunks end-to-end; emits one-shot warning. `runAcpReview` and `runAcpAdversarialReview` forward both options. Exposes `__testing.simulateNotificationDispatch` for deterministic tests.
- `plugins/gemini/scripts/lib/acp-protocol.d.ts` — full rewrite of the notification union.
- `plugins/gemini/scripts/lib/job-observability.mjs` — `model_thought_chunk` joins `model_text_chunk` in the progress-event allow-list.
- `plugins/gemini/scripts/lib/render.mjs` — event-tail block with sanitized event lines, counters, and graceful fallback.
- `plugins/gemini/scripts/gemini-companion.mjs` — `handleTask`, `handleReview`, `handleReviewCommand` parse and validate the new flags, build the stream handler, forward `thinking` through to background workers, refresh `printUsage`.

**User-facing docs**
- `README.md` — new \"Live Progress & Thinking Levels\" section.
- `plugins/gemini/commands/rescue.md` — `argument-hint` and instruction body refreshed.
- `plugins/gemini/commands/review.md` — same.
- `plugins/gemini/agents/gemini-rescue.md` — runtime-flag list refreshed.

## Test plan

- [x] `npm test` — 163 / 163 pass locally
- [x] `node --check` clean on every modified `.mjs`
- [x] `docs/` untracked (planning artifacts stay local per repo convention)
- [x] Unit: thinking resolver across the full model-family matrix (12 tests)
- [x] Unit: stream handler across markers/passthrough/JSON/EPIPE/null-event (12 tests)
- [x] Unit: notification dispatch distinguishes message and thought chunks
- [x] Unit: `model_thought_chunk` event round-trips with chars-only persistence
- [x] Unit: render tail shows last 5, counters, `Ns ago` delta; falls back when events absent
- [x] Unit: `resolveThinkingConfig` handles Gemini 3, Gemini 3.1, Gemini 2.5 Pro/Flash/Flash-Lite, and unknown models
- [x] Unit: one-shot thinking warning guard
- [x] Docs-agreement: rescue.md, review.md, README contain new flags, omit old form
- [x] Companion flag test: `printUsage` lists new flags; handlers parse them
- [x] E2E: companion rejects `--thinking purple` with non-zero exit and usage; `--help` mentions both flags
- [x] Pre-existing 112 tests still pass (no regressions)

## Notes

- Existing `--json` mode continues to write exactly one final stdout payload. Compact markers are auto-suppressed in JSON mode; `--stream-output --json` still writes passthrough to stderr since the user opted in explicitly.
- Raw model prose and raw thought prose are never persisted to job files or status output. Char counts only. Raw chunks appear live on stderr only, and only with `--stream-output`.
- If upstream adds a per-invocation thinking delivery mechanism, the warning line in `runAcpPrompt` is the single update point — swap it for the real delivery call, remove the warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--thinking <off|low|medium|high>` flag for tasks and reviews to control reasoning effort (defaults to medium).
  * Added `--stream-output` flag to stream raw model output and thinking text to stderr; otherwise displays compact progress markers.

* **Documentation**
  * Updated rescue and review command documentation with new flags and behavior.
  * Updated README documenting thinking control, level mapping per model, progress output behavior, and privacy guarantees for raw output.

* **Tests**
  * Added comprehensive test coverage for thinking configuration, stream output handling, and CLI flag validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->