### PR TITLE
fix: spawnDetached logFile option dead code — both ternary branches identical (#29)

### DIFF
--- a/plugins/gemini/scripts/lib/process.mjs
+++ b/plugins/gemini/scripts/lib/process.mjs
@@ -133,18 +133,25 @@ export function terminateProcessTree(pid) {
  * @returns {import("node:child_process").ChildProcess}
  */
 export function spawnDetached(command, args, options = {}) {
-  const logFd = options.logFile ? fs.openSync(options.logFile, "a") : null;
-  const stdio = options.logFile
-    ? ["ignore", "ignore", logFd]
-    : ["ignore", "ignore", "ignore"];
+  let logFd = null;
+  try {
+    logFd = options.logFile ? fs.openSync(options.logFile, "a") : null;
+    const stdio = options.logFile
+      ? ["ignore", "ignore", logFd]
+      : ["ignore", "ignore", "ignore"];
 
-  const child = nodeSpawn(command, args, {
-    cwd: options.cwd,
-    env: options.env ?? process.env,
-    detached: true,
-    stdio
-  });
+    const child = nodeSpawn(command, args, {
+      cwd: options.cwd,
+      env: options.env ?? process.env,
+      detached: true,
+      stdio
+    });
 
-  child.unref();
-  return child;
+    child.unref();
+    return child;
+  } finally {
+    if (typeof logFd === "number") {
+      fs.closeSync(logFd);
+    }
+  }
 }

--- a/plugins/gemini/scripts/lib/process.mjs
+++ b/plugins/gemini/scripts/lib/process.mjs
@@ -3,6 +3,7 @@
  */
 
 import { execFileSync, spawnSync, spawn as nodeSpawn } from "node:child_process";
+import fs from "node:fs";
 import process from "node:process";
 
 /**
@@ -132,8 +133,9 @@ export function terminateProcessTree(pid) {
  * @returns {import("node:child_process").ChildProcess}
  */
 export function spawnDetached(command, args, options = {}) {
+  const logFd = options.logFile ? fs.openSync(options.logFile, "a") : null;
   const stdio = options.logFile
-    ? ["ignore", "ignore", "ignore"]
+    ? ["ignore", "ignore", logFd]
     : ["ignore", "ignore", "ignore"];
 
   const child = nodeSpawn(command, args, {

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -46,19 +46,30 @@ test("spawnDetached redirects stderr to logFile when provided", async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gemini-plugin-test-"));
   const logFile = path.join(dir, "log.txt");
 
-  const child = spawnDetached("node", ["-e", 'process.stderr.write("hello-stderr")'], { logFile });
+  try {
+    const child = spawnDetached("node", ["-e", 'process.stderr.write("hello-stderr")'], { logFile });
+    child.ref();
 
-  await new Promise((resolve) => {
-    child.on("exit", () => {
-      const content = fs.readFileSync(logFile, "utf8");
-      assert.equal(content, "hello-stderr");
-      fs.rmSync(dir, { recursive: true, force: true });
-      resolve();
+    await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("child did not exit in time")), 5000);
+      child.once("error", (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+      child.once("exit", () => {
+        clearTimeout(timer);
+        resolve();
+      });
     });
-  });
+
+    const content = fs.readFileSync(logFile, "utf8");
+    assert.equal(content, "hello-stderr");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 });
 
-test("spawnDetached without logFile does not create files", () => {
+test("spawnDetached without logFile returns a running child process", () => {
   const child = spawnDetached("node", ["-e", "process.exit(0)"]);
   assert.ok(child.pid > 0);
 });

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
-import { runCommand, binaryAvailable, formatCommandFailure } from "../plugins/gemini/scripts/lib/process.mjs";
+import { runCommand, binaryAvailable, formatCommandFailure, spawnDetached } from "../plugins/gemini/scripts/lib/process.mjs";
 
 test("runCommand captures stdout and stderr", () => {
   const result = runCommand("node", ["-e", 'process.stdout.write("hello")']);
@@ -32,4 +35,30 @@ test("binaryAvailable returns true for node", () => {
 
 test("binaryAvailable returns false for nonexistent binary", () => {
   assert.equal(binaryAvailable("definitely-not-a-real-binary-xyz"), false);
+});
+
+test("spawnDetached returns a child process", () => {
+  const child = spawnDetached("node", ["-e", "setTimeout(() => {}, 100)"]);
+  assert.ok(child.pid > 0);
+});
+
+test("spawnDetached redirects stderr to logFile when provided", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gemini-plugin-test-"));
+  const logFile = path.join(dir, "log.txt");
+
+  const child = spawnDetached("node", ["-e", 'process.stderr.write("hello-stderr")'], { logFile });
+
+  await new Promise((resolve) => {
+    child.on("exit", () => {
+      const content = fs.readFileSync(logFile, "utf8");
+      assert.equal(content, "hello-stderr");
+      fs.rmSync(dir, { recursive: true, force: true });
+      resolve();
+    });
+  });
+});
+
+test("spawnDetached without logFile does not create files", () => {
+  const child = spawnDetached("node", ["-e", "process.exit(0)"]);
+  assert.ok(child.pid > 0);
 });


### PR DESCRIPTION
## Summary
- Fixed `spawnDetached` in `process.mjs` where both ternary branches assigned identical `["ignore", "ignore", "ignore"]` stdio, making the `logFile` option permanently inert
- When `logFile` is provided, stderr is now redirected to the log file via `fs.openSync("a")` instead of being silently ignored
- Added tests verifying stderr is written to the log file when `logFile` is provided, and that `spawnDetached` works correctly without the option

Closes #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Detached processes now support optional file logging to capture output.

* **Tests**
  * Added comprehensive test coverage for detached process file logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->